### PR TITLE
Bump revision number

### DIFF
--- a/paper/P2728.md
+++ b/paper/P2728.md
@@ -1,6 +1,6 @@
 ---
 title: "Unicode in the Library, Part 1: UTF Transcoding"
-document: P2728R7
+document: P2728R8
 date: 2024-10-06
 audience:
   - SG-16 Unicode


### PR DESCRIPTION
Bump the revision number from R7 to R8 to reflect the presence of as-yet-unpublished changes not present in R7.