### PR TITLE
Remove iterator_interface; use transform_view for code unit views

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -23,13 +23,13 @@ option(
 )
 
 FetchContent_Declare(
-    beman.iterator_interface
-    GIT_REPOSITORY https://github.com/bemanproject/iterator_interface.git
-    GIT_TAG 94adc3ea613384dc9da64c9de1a7d9a21395ede7
+    beman.transform_view_26
+    GIT_REPOSITORY https://github.com/tzlaine/transform_view_26.git
+    GIT_TAG a939df439de83be949349c662344563263f81ecd
     EXCLUDE_FROM_ALL
 )
 
-FetchContent_MakeAvailable(beman.iterator_interface)
+FetchContent_MakeAvailable(beman.transform_view_26)
 
 add_subdirectory(src/beman/utf_view)
 

--- a/README.md
+++ b/README.md
@@ -122,7 +122,7 @@ beman.utf_view has the following minimum compiler requirements:
 
 ### Dependencies
 
-beman.utf_view depends on [beman.iterator_interface](https://github.com/bemanproject/iterator_interface). It brings in this library via CMake FetchContent.
+beman.utf_view depends on [beman.transform_view_26](https://github.com/tzlaine/transform_view_26/). It brings in this library via CMake FetchContent.
 
 ### Instructions
 

--- a/include/beman/utf_view/code_unit_view.hpp
+++ b/include/beman/utf_view/code_unit_view.hpp
@@ -9,548 +9,40 @@
 #define BEMAN_UTF_VIEW_CODE_UNIT_VIEW_HPP
 
 #include <beman/utf_view/detail/concepts.hpp>
-#include <beman/iterator_interface/iterator_interface.hpp>
-#include <iterator>
+#include <beman/transform_view_26/transform_view.hpp>
 #include <ranges>
 #include <type_traits>
-#include <utility>
 
 namespace beman::utf_view {
 
 /* PAPER: namespace std::uc { */
 
+namespace detail {
+
 /* PAPER */
 
-template <class I>
-consteval auto exposition_only_iterator_to_tag() { // @*exposition only*@
-  if constexpr (std::random_access_iterator<I>) {
-    return std::random_access_iterator_tag{};
-  } else if constexpr (std::bidirectional_iterator<I>) {
-    return std::bidirectional_iterator_tag{};
-  } else if constexpr (std::forward_iterator<I>) {
-    return std::forward_iterator_tag{};
-  } else if constexpr (std::input_iterator<I>) {
-    return std::input_iterator_tag{};
-  }
-}
-
-template <class I>
-using exposition_only_iterator_to_tag_t =
-    decltype(exposition_only_iterator_to_tag<I>()); // @*exposition only*@
-
-template <typename V, typename ToType>
-concept exposition_only_convertible_to_charN_t_view =
-    exposition_only_code_unit_to<ToType> && std::ranges::view<V> &&
-    std::convertible_to<std::ranges::range_reference_t<V>, ToType>;
-
-template <exposition_only_convertible_to_charN_t_view<char8_t> V>
-class as_char8_t_view : public std::ranges::view_interface<as_char8_t_view<V>> {
-  V base_ = V(); // @*exposition only*@
-
-  template <bool Const>
-  class exposition_only_iterator; // @*exposition only*@
-  template <bool Const>
-  class exposition_only_sentinel; // @*exposition only*@
-
-public:
-  constexpr as_char8_t_view()
-    requires std::default_initializable<V>
-  = default;
-  constexpr as_char8_t_view(V base)
-      : base_(std::move(base)) { }
-
-  constexpr V& base() & {
-    return base_;
-  }
-  constexpr const V& base() const&
-    requires std::copy_constructible<V>
-  {
-    return base_;
-  }
-  constexpr V base() && {
-    return std::move(base_);
-  }
-
-  constexpr exposition_only_iterator<false> begin() {
-    return exposition_only_iterator<false>{std::ranges::begin(base_)};
-  }
-  constexpr exposition_only_iterator<true> begin() const
-    requires std::ranges::range<const V>
-  {
-    return exposition_only_iterator<true>{std::ranges::begin(base_)};
-  }
-
-  constexpr exposition_only_sentinel<false> end() {
-    return exposition_only_sentinel<false>{std::ranges::end(base_)};
-  }
-  constexpr exposition_only_iterator<false> end()
-    requires std::ranges::common_range<V>
-  {
-    return exposition_only_iterator<false>{std::ranges::end(base_)};
-  }
-  constexpr exposition_only_sentinel<true> end() const
-    requires std::ranges::range<const V>
-  {
-    return exposition_only_sentinel<true>{std::ranges::end(base_)};
-  }
-  constexpr exposition_only_iterator<true> end() const
-    requires std::ranges::common_range<const V>
-  {
-    return exposition_only_iterator<true>{std::ranges::end(base_)};
-  }
-
-  constexpr auto size()
-    requires std::ranges::sized_range<V>
-  {
-    return std::ranges::size(base_);
-  }
-  constexpr auto size() const
-    requires std::ranges::sized_range<const V>
-  {
-    return std::ranges::size(base_);
+template <class T>
+struct exposition_only_implicit_cast_to {
+  constexpr T operator()(auto x) const noexcept {
+    return x;
   }
 };
-
-template <exposition_only_convertible_to_charN_t_view<char8_t> V>
-template <bool Const>
-class as_char8_t_view<V>::exposition_only_iterator
-    : public beman::iterator_interface::iterator_interface<
-          exposition_only_iterator_to_tag_t<
-              std::ranges::iterator_t<exposition_only_maybe_const<Const, V>>>,
-          char8_t, char8_t, void, std::ptrdiff_t> {
-public:
-  using reference_type = char8_t;
-
-private:
-  using exposition_only_iterator_type = std::ranges::iterator_t<
-      exposition_only_maybe_const<Const, V>>; // @*exposition only*@
-
-  friend beman::iterator_interface::iterator_interface_access;
-
-  constexpr exposition_only_iterator_type& base_reference() noexcept {
-    return it_;
-  } // @*exposition only*@
-  constexpr exposition_only_iterator_type base_reference() const {
-    return it_;
-  } // @*exposition only*@
-
-  exposition_only_iterator_type it_ =
-      exposition_only_iterator_type(); // @*exposition only*@
-
-public:
-  constexpr exposition_only_iterator() = default;
-  constexpr exposition_only_iterator(exposition_only_iterator_type it)
-      : it_(std::move(it)) { }
-
-  constexpr reference_type operator*() const {
-    return *it_;
-  }
-};
-
-template <exposition_only_convertible_to_charN_t_view<char8_t> V>
-template <bool Const>
-class as_char8_t_view<V>::exposition_only_sentinel {
-  using exposition_only_base =
-      exposition_only_maybe_const<Const, V>; // @*exposition only*@
-  using exposition_only_sentinel_type =
-      std::ranges::sentinel_t<exposition_only_base>; // @*exposition only*@
-
-  exposition_only_sentinel_type end_ =
-      exposition_only_sentinel_type(); // @*exposition only*@
-
-public:
-  constexpr exposition_only_sentinel() = default;
-  constexpr explicit exposition_only_sentinel(exposition_only_sentinel_type end)
-      : end_(std::move(end)) { }
-  constexpr exposition_only_sentinel(exposition_only_sentinel<!Const> i)
-    requires Const &&
-      std::convertible_to<std::ranges::sentinel_t<V>,
-                          std::ranges::sentinel_t<exposition_only_base>>;
-
-  constexpr exposition_only_sentinel_type base() const {
-    return end_;
-  }
-
-  template <bool OtherConst>
-    requires std::sentinel_for<
-        exposition_only_sentinel_type,
-        std::ranges::iterator_t<exposition_only_maybe_const<OtherConst, V>>>
-  friend constexpr bool operator==(const exposition_only_iterator<OtherConst>& x,
-                                   const exposition_only_sentinel& y) {
-    return x.it_ == y.end_;
-  }
-
-  template <bool OtherConst>
-    requires std::sized_sentinel_for<
-        exposition_only_sentinel_type,
-        std::ranges::iterator_t<exposition_only_maybe_const<OtherConst, V>>>
-  friend constexpr std::ranges::range_difference_t<
-      exposition_only_maybe_const<OtherConst, V>>
-  operator-(const exposition_only_iterator<OtherConst>& x,
-            const exposition_only_sentinel& y) {
-    return x.it_ - y.end_;
-  }
-
-  template <bool OtherConst>
-    requires std::sized_sentinel_for<
-        exposition_only_sentinel_type,
-        std::ranges::iterator_t<exposition_only_maybe_const<OtherConst, V>>>
-  friend constexpr std::ranges::range_difference_t<
-      exposition_only_maybe_const<OtherConst, V>>
-  operator-(const exposition_only_sentinel& y,
-            const exposition_only_iterator<OtherConst>& x) {
-    return y.end_ - x.it_;
-  }
-};
-
-template <class R>
-as_char8_t_view(R&&) -> as_char8_t_view<std::views::all_t<R>>;
-
-template <exposition_only_convertible_to_charN_t_view<char16_t> V>
-class as_char16_t_view : public std::ranges::view_interface<as_char16_t_view<V>> {
-  V base_ = V(); // @*exposition only*@
-
-  template <bool Const>
-  class exposition_only_iterator; // @*exposition only*@
-  template <bool Const>
-  class exposition_only_sentinel; // @*exposition only*@
-
-public:
-  constexpr as_char16_t_view()
-    requires std::default_initializable<V>
-  = default;
-  constexpr as_char16_t_view(V base)
-      : base_(std::move(base)) { }
-
-  constexpr V& base() & {
-    return base_;
-  }
-  constexpr const V& base() const&
-    requires std::copy_constructible<V>
-  {
-    return base_;
-  }
-  constexpr V base() && {
-    return std::move(base_);
-  }
-
-  constexpr exposition_only_iterator<false> begin() {
-    return exposition_only_iterator<false>{std::ranges::begin(base_)};
-  }
-  constexpr exposition_only_iterator<true> begin() const
-    requires std::ranges::range<const V>
-  {
-    return exposition_only_iterator<true>{std::ranges::begin(base_)};
-  }
-
-  constexpr exposition_only_sentinel<false> end() {
-    return exposition_only_sentinel<false>{std::ranges::end(base_)};
-  }
-  constexpr exposition_only_iterator<false> end()
-    requires std::ranges::common_range<V>
-  {
-    return exposition_only_iterator<false>{std::ranges::end(base_)};
-  }
-  constexpr exposition_only_sentinel<true> end() const
-    requires std::ranges::range<const V>
-  {
-    return exposition_only_sentinel<true>{std::ranges::end(base_)};
-  }
-  constexpr exposition_only_iterator<true> end() const
-    requires std::ranges::common_range<const V>
-  {
-    return exposition_only_iterator<true>{std::ranges::end(base_)};
-  }
-
-  constexpr auto size()
-    requires std::ranges::sized_range<V>
-  {
-    return std::ranges::size(base_);
-  }
-  constexpr auto size() const
-    requires std::ranges::sized_range<const V>
-  {
-    return std::ranges::size(base_);
-  }
-};
-
-template <exposition_only_convertible_to_charN_t_view<char16_t> V>
-template <bool Const>
-class as_char16_t_view<V>::exposition_only_iterator
-    : public beman::iterator_interface::iterator_interface<
-          exposition_only_iterator_to_tag_t<
-              std::ranges::iterator_t<exposition_only_maybe_const<Const, V>>>,
-          char16_t, char16_t, void, std::ptrdiff_t> {
-public:
-  using reference_type = char16_t;
-
-private:
-  using exposition_only_iterator_type = std::ranges::iterator_t<
-      exposition_only_maybe_const<Const, V>>; // @*exposition only*@
-
-  friend beman::iterator_interface::iterator_interface_access;
-
-  constexpr exposition_only_iterator_type& base_reference() noexcept {
-    return it_;
-  } // @*exposition only*@
-  constexpr exposition_only_iterator_type base_reference() const {
-    return it_;
-  } // @*exposition only*@
-
-  exposition_only_iterator_type it_ =
-      exposition_only_iterator_type(); // @*exposition only*@
-
-public:
-  constexpr exposition_only_iterator() = default;
-  constexpr exposition_only_iterator(exposition_only_iterator_type it)
-      : it_(std::move(it)) { }
-
-  constexpr reference_type operator*() const {
-    return *it_;
-  }
-};
-
-template <exposition_only_convertible_to_charN_t_view<char16_t> V>
-template <bool Const>
-class as_char16_t_view<V>::exposition_only_sentinel {
-  using exposition_only_base =
-      exposition_only_maybe_const<Const, V>; // @*exposition only*@
-  using exposition_only_sentinel_type =
-      std::ranges::sentinel_t<exposition_only_base>; // @*exposition only*@
-
-  exposition_only_sentinel_type end_ =
-      exposition_only_sentinel_type(); // @*exposition only*@
-
-public:
-  constexpr exposition_only_sentinel() = default;
-  constexpr explicit exposition_only_sentinel(exposition_only_sentinel_type end)
-      : end_(std::move(end)) { }
-  constexpr exposition_only_sentinel(exposition_only_sentinel<!Const> i)
-    requires Const &&
-      std::convertible_to<std::ranges::sentinel_t<V>,
-                          std::ranges::sentinel_t<exposition_only_base>>;
-
-  constexpr exposition_only_sentinel_type base() const {
-    return end_;
-  }
-
-  template <bool OtherConst>
-    requires std::sentinel_for<
-        exposition_only_sentinel_type,
-        std::ranges::iterator_t<exposition_only_maybe_const<OtherConst, V>>>
-  friend constexpr bool operator==(const exposition_only_iterator<OtherConst>& x,
-                                   const exposition_only_sentinel& y) {
-    return x.it_ == y.end_;
-  }
-
-  template <bool OtherConst>
-    requires std::sized_sentinel_for<
-        exposition_only_sentinel_type,
-        std::ranges::iterator_t<exposition_only_maybe_const<OtherConst, V>>>
-  friend constexpr std::ranges::range_difference_t<
-      exposition_only_maybe_const<OtherConst, V>>
-  operator-(const exposition_only_iterator<OtherConst>& x,
-            const exposition_only_sentinel& y) {
-    return x.it_ - y.end_;
-  }
-
-  template <bool OtherConst>
-    requires std::sized_sentinel_for<
-        exposition_only_sentinel_type,
-        std::ranges::iterator_t<exposition_only_maybe_const<OtherConst, V>>>
-  friend constexpr std::ranges::range_difference_t<
-      exposition_only_maybe_const<OtherConst, V>>
-  operator-(const exposition_only_sentinel& y,
-            const exposition_only_iterator<OtherConst>& x) {
-    return y.end_ - x.it_;
-  }
-};
-
-template <class R>
-as_char16_t_view(R&&) -> as_char16_t_view<std::views::all_t<R>>;
-
-template <exposition_only_convertible_to_charN_t_view<char32_t> V>
-class as_char32_t_view : public std::ranges::view_interface<as_char32_t_view<V>> {
-  V base_ = V(); // @*exposition only*@
-
-  template <bool Const>
-  class exposition_only_iterator; // @*exposition only*@
-  template <bool Const>
-  class exposition_only_sentinel; // @*exposition only*@
-
-public:
-  constexpr as_char32_t_view()
-    requires std::default_initializable<V>
-  = default;
-  constexpr as_char32_t_view(V base)
-      : base_(std::move(base)) { }
-
-  constexpr V& base() & {
-    return base_;
-  }
-  constexpr const V& base() const&
-    requires std::copy_constructible<V>
-  {
-    return base_;
-  }
-  constexpr V base() && {
-    return std::move(base_);
-  }
-
-  constexpr exposition_only_iterator<false> begin() {
-    return exposition_only_iterator<false>{std::ranges::begin(base_)};
-  }
-  constexpr exposition_only_iterator<true> begin() const
-    requires std::ranges::range<const V>
-  {
-    return exposition_only_iterator<true>{std::ranges::begin(base_)};
-  }
-
-  constexpr exposition_only_sentinel<false> end() {
-    return exposition_only_sentinel<false>{std::ranges::end(base_)};
-  }
-  constexpr exposition_only_iterator<false> end()
-    requires std::ranges::common_range<V>
-  {
-    return exposition_only_iterator<false>{std::ranges::end(base_)};
-  }
-  constexpr exposition_only_sentinel<true> end() const
-    requires std::ranges::range<const V>
-  {
-    return exposition_only_sentinel<true>{std::ranges::end(base_)};
-  }
-  constexpr exposition_only_iterator<true> end() const
-    requires std::ranges::common_range<const V>
-  {
-    return exposition_only_iterator<true>{std::ranges::end(base_)};
-  }
-
-  constexpr auto size()
-    requires std::ranges::sized_range<V>
-  {
-    return std::ranges::size(base_);
-  }
-  constexpr auto size() const
-    requires std::ranges::sized_range<const V>
-  {
-    return std::ranges::size(base_);
-  }
-};
-
-template <exposition_only_convertible_to_charN_t_view<char32_t> V>
-template <bool Const>
-class as_char32_t_view<V>::exposition_only_iterator
-    : public beman::iterator_interface::iterator_interface<
-          exposition_only_iterator_to_tag_t<
-              std::ranges::iterator_t<exposition_only_maybe_const<Const, V>>>,
-          char32_t, char32_t, void, std::ptrdiff_t> {
-public:
-  using reference_type = char32_t;
-
-private:
-  using exposition_only_iterator_type = std::ranges::iterator_t<
-      exposition_only_maybe_const<Const, V>>; // @*exposition only*@
-
-  friend beman::iterator_interface::iterator_interface_access;
-
-  constexpr exposition_only_iterator_type& base_reference() noexcept {
-    return it_;
-  } // @*exposition only*@
-  constexpr exposition_only_iterator_type base_reference() const {
-    return it_;
-  } // @*exposition only*@
-
-  exposition_only_iterator_type it_ =
-      exposition_only_iterator_type(); // @*exposition only*@
-
-public:
-  constexpr exposition_only_iterator() = default;
-  constexpr exposition_only_iterator(exposition_only_iterator_type it)
-      : it_(std::move(it)) { }
-
-  constexpr reference_type operator*() const {
-    return *it_;
-  }
-};
-
-template <exposition_only_convertible_to_charN_t_view<char32_t> V>
-template <bool Const>
-class as_char32_t_view<V>::exposition_only_sentinel {
-  using exposition_only_base =
-      exposition_only_maybe_const<Const, V>; // @*exposition only*@
-  using exposition_only_sentinel_type =
-      std::ranges::sentinel_t<exposition_only_base>; // @*exposition only*@
-
-  exposition_only_sentinel_type end_ =
-      exposition_only_sentinel_type(); // @*exposition only*@
-
-public:
-  constexpr exposition_only_sentinel() = default;
-  constexpr explicit exposition_only_sentinel(exposition_only_sentinel_type end)
-      : end_(std::move(end)) { }
-  constexpr exposition_only_sentinel(exposition_only_sentinel<!Const> i)
-    requires Const &&
-      std::convertible_to<std::ranges::sentinel_t<V>,
-                          std::ranges::sentinel_t<exposition_only_base>>;
-
-  constexpr exposition_only_sentinel_type base() const {
-    return end_;
-  }
-
-  template <bool OtherConst>
-    requires std::sentinel_for<
-        exposition_only_sentinel_type,
-        std::ranges::iterator_t<exposition_only_maybe_const<OtherConst, V>>>
-  friend constexpr bool operator==(const exposition_only_iterator<OtherConst>& x,
-                                   const exposition_only_sentinel& y) {
-    return x.it_ == y.end_;
-  }
-
-  template <bool OtherConst>
-    requires std::sized_sentinel_for<
-        exposition_only_sentinel_type,
-        std::ranges::iterator_t<exposition_only_maybe_const<OtherConst, V>>>
-  friend constexpr std::ranges::range_difference_t<
-      exposition_only_maybe_const<OtherConst, V>>
-  operator-(const exposition_only_iterator<OtherConst>& x,
-            const exposition_only_sentinel& y) {
-    return x.it_ - y.end_;
-  }
-
-  template <bool OtherConst>
-    requires std::sized_sentinel_for<
-        exposition_only_sentinel_type,
-        std::ranges::iterator_t<exposition_only_maybe_const<OtherConst, V>>>
-  friend constexpr std::ranges::range_difference_t<
-      exposition_only_maybe_const<OtherConst, V>>
-  operator-(const exposition_only_sentinel& y,
-            const exposition_only_iterator<OtherConst>& x) {
-    return y.end_ - x.it_;
-  }
-};
-
-template <class R>
-as_char32_t_view(R&&) -> as_char32_t_view<std::views::all_t<R>>;
 
 /* !PAPER */
 
+} // namespace detail
+
 namespace detail {
 
-  template <exposition_only_code_unit_to ToType, std::ranges::view V>
-  using as_charN_t_view =
-      std::conditional_t<std::is_same_v<ToType, char8_t>, as_char8_t_view<V>,
-                         std::conditional_t<std::is_same_v<ToType, char16_t>,
-                                            as_char16_t_view<V>, as_char32_t_view<V>>>;
-
-  template <exposition_only_code_unit_to ToType>
+  template <exposition_only_code_unit_to Char>
   struct as_code_unit_impl
-      : std::ranges::range_adaptor_closure<as_code_unit_impl<ToType>> {
+      : std::ranges::range_adaptor_closure<as_code_unit_impl<Char>> {
     template <std::ranges::range R>
-      requires std::convertible_to<std::ranges::range_reference_t<R>, ToType>
+      requires std::convertible_to<std::ranges::range_reference_t<R>, Char>
     constexpr auto operator()(R&& r) const {
       using T = std::remove_cvref_t<R>;
       if constexpr (exposition_only_is_empty_view<T>) {
-        return std::ranges::empty_view<ToType>{};
+        return std::ranges::empty_view<Char>{};
       } else if constexpr (std::is_bounded_array_v<T>) {
         constexpr auto n = std::extent_v<T>;
         auto first{std::ranges::begin(r)};
@@ -559,10 +51,11 @@ namespace detail {
           --last;
         }
         std::ranges::subrange subrange(first, last);
-        return as_charN_t_view<ToType, decltype(subrange)>(std::move(subrange));
+        return beman::transform_view_26::transform_view(
+            std::move(subrange), exposition_only_implicit_cast_to<Char>{});
       } else {
-        auto view = std::views::all(std::forward<R>(r));
-        return as_charN_t_view<ToType, decltype(view)>(std::move(view));
+        return beman::transform_view_26::transform_view(
+            std::move(r), exposition_only_implicit_cast_to<Char>{});
       }
     }
   };
@@ -580,34 +73,9 @@ inline constexpr detail::as_code_unit_impl<char32_t> as_char32_t;
 /* PAPER:   inline constexpr @*unspecified*@ as_char16_t; */
 /* PAPER:                                                 */
 /* PAPER:   inline constexpr @*unspecified*@ as_char32_t; */
-/* PAPER:                                                 */
-/* PAPER: }                                               */
+
+/* PAPER: } */
 
 } // namespace beman::utf_view
-
-template <class V>
-inline constexpr bool std::ranges::enable_borrowed_range<beman::utf_view::as_char8_t_view<V>> =
-    std::ranges::enable_borrowed_range<V>;
-
-template <class V>
-inline constexpr bool std::ranges::enable_borrowed_range<beman::utf_view::as_char16_t_view<V>> =
-    std::ranges::enable_borrowed_range<V>;
-
-template <class V>
-inline constexpr bool std::ranges::enable_borrowed_range<beman::utf_view::as_char32_t_view<V>> =
-    std::ranges::enable_borrowed_range<V>;
-
-/* PAPER: namespace std::ranges {                                                                                 */
-/* PAPER:                                                                                                         */
-/* PAPER:   template <class V>                                                                                    */
-/* PAPER:   inline constexpr bool enable_borrowed_range<std::uc::as_char8_t_view<V>> = enable_borrowed_range<V>;  */
-/* PAPER:                                                                                                         */
-/* PAPER:   template <class V>                                                                                    */
-/* PAPER:   inline constexpr bool enable_borrowed_range<std::uc::as_char16_t_view<V>> = enable_borrowed_range<V>; */
-/* PAPER:                                                                                                         */
-/* PAPER:   template <class V>                                                                                    */
-/* PAPER:   inline constexpr bool enable_borrowed_range<std::uc::as_char32_t_view<V>> = enable_borrowed_range<V>; */
-/* PAPER:                                                                                                         */
-/* PAPER: }                                                                                                       */
 
 #endif // BEMAN_UTF_VIEW_CODE_UNIT_VIEW_HPP

--- a/paper/P2728.md
+++ b/paper/P2728.md
@@ -115,9 +115,9 @@ monofont: "DejaVu Sans Mono"
 ## Changes since R7
 
 - Add playing card example
-- Remove iterator_interface from `@*utf-iterator*@` and change
-  `as_charN_t_view::@*iterator*@` dependency from proxy_iterator_interface to
-  iterator_interface
+- Remove `iterator_interface` from `@*utf-iterator*@`
+- Replace code unit views with range adaptor closure objects that are
+  expression-equivalent to P3117 `transform_view`
 
 # Motivation
 
@@ -272,7 +272,7 @@ auto input_utf8 =
 
 ## Dependencies
 
-This proposal depends on the existence of [@P2727R4] "std::iterator_interface".
+This proposal depends on the existence of [@P3117R1] "Extending Conditionally Borrowed".
 
 ## Discussion of whether transcoding views should accept ranges of `char` and `wchar_t`
 
@@ -5512,14 +5512,15 @@ template. `to_utf8` produces `to_utf8_view`s, `to_utf16` produces
 `to_utf16_view`s, and `to_utf32` produces `utf32_view`s. `to_utf<ToType>` is
 equivalent to `to_utf8` if `ToType` is `char8_t`, `to_utf16` if `ToType` is
 `char16_t`, and `to_utf32` if `ToType` is `char32_t`. Let `to_utfN` denote any
-one of `to_utf8`, `to_utf16`, and `to_utf32`, and let `V` denote the
-`to_utfN_view` associated with that object. Let `E` be an expression and let
-`T` be `remove_cvref_t<decltype((E))>`. If `decltype((E))` does not model
+one of `to_utf8`, `to_utf16`, and `to_utf32`, let `Char` be the corresponding
+character type for `to_utfN`, and let `V` denote the `to_utfN_view` associated
+with that object. Let `E` be an expression and let `T` be
+`remove_cvref_t<decltype((E))>`. If `decltype((E))` does not model
 `@*utf-range*@`, `to_utfN(E)` is ill-formed. The expression `to_utfN(E)` is
 expression-equivalent to:
 
-- If `T` is a specialization of `empty_view` ([range.empty.view]), then
-  `empty_view<ToType>{}`.
+- If `Char` is a specialization of `empty_view` ([range.empty.view]), then
+  `empty_view<Char>{}`.
 
 - Otherwise, if `T` is an array type of known bound, then:
 
@@ -5537,414 +5538,45 @@ implementation will construct `utf_view::begin()` and `utf_view::end()` and
 compare them, whereas we can simply use the underlying range's `empty()`,
 since a `utf_view` is empty if and only if its underlying range is empty.
 
-## Add code unit views and adaptors
+## Add code unit adaptors
 
-```c++
+```
 namespace std::uc {
 
-  template<class I>
-  consteval auto @*iterator-to-tag*@() { // @*exposition only*@
-    if constexpr (random_access_iterator<I>) {
-      return random_access_iterator_tag{};
-    } else if constexpr (bidirectional_iterator<I>) {
-      return bidirectional_iterator_tag{};
-    } else if constexpr (forward_iterator<I>) {
-      return forward_iterator_tag{};
-    } else if constexpr (input_iterator<I>) {
-      return input_iterator_tag{};
-    }
-  }
-
-  template<class I>
-  using @*iterator-to-tag-t*@ = decltype(@*iterator-to-tag*@<I>()); // @*exposition only*@
-
-  template<typename V, typename ToType>
-  concept @*convertible-to-charN-t-view*@ = @*code-unit-to*@<ToType> && ranges::view<V> && convertible_to<ranges::range_reference_t<V>, ToType>;
-
-  template<@*convertible-to-charN-t-view*@<char8_t> V>
-  class as_char8_t_view : public ranges::view_interface<as_char8_t_view<V>> {
-    V base_ = V(); // @*exposition only*@
-
-    template<bool Const>
-    class @*iterator*@; // @*exposition only*@
-    template<bool Const>
-    class @*sentinel*@; // @*exposition only*@
-
-  public:
-    constexpr as_char8_t_view() requires default_initializable<V> = default;
-    constexpr as_char8_t_view(V base) : base_(move(base)) {}
-
-    constexpr V& base() & { return base_; }
-    constexpr const V& base() const& requires copy_constructible<V>
-    {
-      return base_;
-    }
-    constexpr V base() && { return move(base_); }
-
-    constexpr @*iterator*@<false> begin() { return @*iterator*@<false>{ranges::begin(base_)}; }
-    constexpr @*iterator*@<true> begin() const requires ranges::range<const V>
-    {
-      return @*iterator*@<true>{ranges::begin(base_)};
-    }
-
-    constexpr @*sentinel*@<false> end() { return @*sentinel*@<false>{ranges::end(base_)}; }
-    constexpr @*iterator*@<false> end() requires ranges::common_range<V>
-    {
-      return @*iterator*@<false>{ranges::end(base_)};
-    }
-    constexpr @*sentinel*@<true> end() const requires ranges::range<const V>
-    {
-      return @*sentinel*@<true>{ranges::end(base_)};
-    }
-    constexpr @*iterator*@<true> end() const requires ranges::common_range<const V>
-    {
-      return @*iterator*@<true>{ranges::end(base_)};
-    }
-
-    constexpr auto size() requires ranges::sized_range<V>
-    {
-      return ranges::size(base_);
-    }
-    constexpr auto size() const requires ranges::sized_range<const V>
-    {
-      return ranges::size(base_);
-    }
+  template<class T>
+  struct @*implicit-cast-to*@ {
+    constexpr T operator()(auto x) const noexcept { return x; }
   };
 
-  template<@*convertible-to-charN-t-view*@<char8_t> V>
-  template<bool Const>
-  class as_char8_t_view<V>::@*iterator*@
-      : public iterator_interface<@*iterator-to-tag-t*@<ranges::iterator_t<@*maybe-const*@<Const, V>>>, char8_t, char8_t, void, ptrdiff_t> {
-  public:
-    using reference_type = char8_t;
-
-  private:
-    using @*iterator-type*@ = ranges::iterator_t<@*maybe-const*@<Const, V>>; // @*exposition only*@
-
-    friend access;
-
-    constexpr @*iterator-type*@& base_reference() noexcept { return it_; } // @*exposition only*@
-    constexpr @*iterator-type*@ base_reference() const { return it_; } // @*exposition only*@
-
-    @*iterator-type*@ it_ = @*iterator-type*@(); // @*exposition only*@
-
-  public:
-    constexpr @*iterator*@() = default;
-    constexpr @*iterator*@(@*iterator-type*@ it) : it_(move(it)) {}
-
-    constexpr reference_type operator*() const { return *it_; }
-  };
-
-  template<@*convertible-to-charN-t-view*@<char8_t> V>
-  template<bool Const>
-  class as_char8_t_view<V>::@*sentinel*@ {
-    using @*base*@ = @*maybe-const*@<Const, V>; // @*exposition only*@
-    using @*sentinel-type*@ = ranges::sentinel_t<@*base*@>; // @*exposition only*@
-
-    @*sentinel-type*@ end_ = @*sentinel-type*@(); // @*exposition only*@
-
-  public:
-    constexpr @*sentinel*@() = default;
-    constexpr explicit @*sentinel*@(@*sentinel-type*@ end) : end_(move(end)) {}
-    constexpr @*sentinel*@(@*sentinel*@<!Const> i) requires Const && convertible_to<ranges::sentinel_t<V>, ranges::sentinel_t<@*base*@>>;
-
-    constexpr @*sentinel-type*@ base() const { return end_; }
-
-    template<bool OtherConst>
-      requires sentinel_for<@*sentinel-type*@, ranges::iterator_t<@*maybe-const*@<OtherConst, V>>>
-    friend constexpr bool operator==(const @*iterator*@<OtherConst>& x, const @*sentinel*@& y) {
-      return x.it_ == y.end_;
-    }
-
-    template<bool OtherConst>
-      requires sized_sentinel_for<@*sentinel-type*@, ranges::iterator_t<@*maybe-const*@<OtherConst, V>>>
-    friend constexpr ranges::range_difference_t<@*maybe-const*@<OtherConst, V>> operator-(const @*iterator*@<OtherConst>& x, const @*sentinel*@& y) {
-      return x.it_ - y.end_;
-    }
-
-    template<bool OtherConst>
-      requires sized_sentinel_for<@*sentinel-type*@, ranges::iterator_t<@*maybe-const*@<OtherConst, V>>>
-    friend constexpr ranges::range_difference_t<@*maybe-const*@<OtherConst, V>> operator-(const @*sentinel*@& y, const @*iterator*@<OtherConst>& x) {
-      return y.end_ - x.it_;
-    }
-  };
-
-  template<class R>
-  as_char8_t_view(R&&) -> as_char8_t_view<views::all_t<R>>;
-
-  template<@*convertible-to-charN-t-view*@<char16_t> V>
-  class as_char16_t_view : public ranges::view_interface<as_char16_t_view<V>> {
-    V base_ = V(); // @*exposition only*@
-
-    template<bool Const>
-    class @*iterator*@; // @*exposition only*@
-    template<bool Const>
-    class @*sentinel*@; // @*exposition only*@
-
-  public:
-    constexpr as_char16_t_view() requires default_initializable<V> = default;
-    constexpr as_char16_t_view(V base) : base_(move(base)) {}
-
-    constexpr V& base() & { return base_; }
-    constexpr const V& base() const& requires copy_constructible<V>
-    {
-      return base_;
-    }
-    constexpr V base() && { return move(base_); }
-
-    constexpr @*iterator*@<false> begin() { return @*iterator*@<false>{ranges::begin(base_)}; }
-    constexpr @*iterator*@<true> begin() const requires ranges::range<const V>
-    {
-      return @*iterator*@<true>{ranges::begin(base_)};
-    }
-
-    constexpr @*sentinel*@<false> end() { return @*sentinel*@<false>{ranges::end(base_)}; }
-    constexpr @*iterator*@<false> end() requires ranges::common_range<V>
-    {
-      return @*iterator*@<false>{ranges::end(base_)};
-    }
-    constexpr @*sentinel*@<true> end() const requires ranges::range<const V>
-    {
-      return @*sentinel*@<true>{ranges::end(base_)};
-    }
-    constexpr @*iterator*@<true> end() const requires ranges::common_range<const V>
-    {
-      return @*iterator*@<true>{ranges::end(base_)};
-    }
-
-    constexpr auto size() requires ranges::sized_range<V>
-    {
-      return ranges::size(base_);
-    }
-    constexpr auto size() const requires ranges::sized_range<const V>
-    {
-      return ranges::size(base_);
-    }
-  };
-
-  template<@*convertible-to-charN-t-view*@<char16_t> V>
-  template<bool Const>
-  class as_char16_t_view<V>::@*iterator*@
-      : public iterator_interface<@*iterator-to-tag-t*@<ranges::iterator_t<@*maybe-const*@<Const, V>>>, char16_t, char16_t, void, ptrdiff_t> {
-  public:
-    using reference_type = char16_t;
-
-  private:
-    using @*iterator-type*@ = ranges::iterator_t<@*maybe-const*@<Const, V>>; // @*exposition only*@
-
-    friend access;
-
-    constexpr @*iterator-type*@& base_reference() noexcept { return it_; } // @*exposition only*@
-    constexpr @*iterator-type*@ base_reference() const { return it_; } // @*exposition only*@
-
-    @*iterator-type*@ it_ = @*iterator-type*@(); // @*exposition only*@
-
-  public:
-    constexpr @*iterator*@() = default;
-    constexpr @*iterator*@(@*iterator-type*@ it) : it_(move(it)) {}
-
-    constexpr reference_type operator*() const { return *it_; }
-  };
-
-  template<@*convertible-to-charN-t-view*@<char16_t> V>
-  template<bool Const>
-  class as_char16_t_view<V>::@*sentinel*@ {
-    using @*base*@ = @*maybe-const*@<Const, V>; // @*exposition only*@
-    using @*sentinel-type*@ = ranges::sentinel_t<@*base*@>; // @*exposition only*@
-
-    @*sentinel-type*@ end_ = @*sentinel-type*@(); // @*exposition only*@
-
-  public:
-    constexpr @*sentinel*@() = default;
-    constexpr explicit @*sentinel*@(@*sentinel-type*@ end) : end_(move(end)) {}
-    constexpr @*sentinel*@(@*sentinel*@<!Const> i) requires Const && convertible_to<ranges::sentinel_t<V>, ranges::sentinel_t<@*base*@>>;
-
-    constexpr @*sentinel-type*@ base() const { return end_; }
-
-    template<bool OtherConst>
-      requires sentinel_for<@*sentinel-type*@, ranges::iterator_t<@*maybe-const*@<OtherConst, V>>>
-    friend constexpr bool operator==(const @*iterator*@<OtherConst>& x, const @*sentinel*@& y) {
-      return x.it_ == y.end_;
-    }
-
-    template<bool OtherConst>
-      requires sized_sentinel_for<@*sentinel-type*@, ranges::iterator_t<@*maybe-const*@<OtherConst, V>>>
-    friend constexpr ranges::range_difference_t<@*maybe-const*@<OtherConst, V>> operator-(const @*iterator*@<OtherConst>& x, const @*sentinel*@& y) {
-      return x.it_ - y.end_;
-    }
-
-    template<bool OtherConst>
-      requires sized_sentinel_for<@*sentinel-type*@, ranges::iterator_t<@*maybe-const*@<OtherConst, V>>>
-    friend constexpr ranges::range_difference_t<@*maybe-const*@<OtherConst, V>> operator-(const @*sentinel*@& y, const @*iterator*@<OtherConst>& x) {
-      return y.end_ - x.it_;
-    }
-  };
-
-  template<class R>
-  as_char16_t_view(R&&) -> as_char16_t_view<views::all_t<R>>;
-
-  template<@*convertible-to-charN-t-view*@<char32_t> V>
-  class as_char32_t_view : public ranges::view_interface<as_char32_t_view<V>> {
-    V base_ = V(); // @*exposition only*@
-
-    template<bool Const>
-    class @*iterator*@; // @*exposition only*@
-    template<bool Const>
-    class @*sentinel*@; // @*exposition only*@
-
-  public:
-    constexpr as_char32_t_view() requires default_initializable<V> = default;
-    constexpr as_char32_t_view(V base) : base_(move(base)) {}
-
-    constexpr V& base() & { return base_; }
-    constexpr const V& base() const& requires copy_constructible<V>
-    {
-      return base_;
-    }
-    constexpr V base() && { return move(base_); }
-
-    constexpr @*iterator*@<false> begin() { return @*iterator*@<false>{ranges::begin(base_)}; }
-    constexpr @*iterator*@<true> begin() const requires ranges::range<const V>
-    {
-      return @*iterator*@<true>{ranges::begin(base_)};
-    }
-
-    constexpr @*sentinel*@<false> end() { return @*sentinel*@<false>{ranges::end(base_)}; }
-    constexpr @*iterator*@<false> end() requires ranges::common_range<V>
-    {
-      return @*iterator*@<false>{ranges::end(base_)};
-    }
-    constexpr @*sentinel*@<true> end() const requires ranges::range<const V>
-    {
-      return @*sentinel*@<true>{ranges::end(base_)};
-    }
-    constexpr @*iterator*@<true> end() const requires ranges::common_range<const V>
-    {
-      return @*iterator*@<true>{ranges::end(base_)};
-    }
-
-    constexpr auto size() requires ranges::sized_range<V>
-    {
-      return ranges::size(base_);
-    }
-    constexpr auto size() const requires ranges::sized_range<const V>
-    {
-      return ranges::size(base_);
-    }
-  };
-
-  template<@*convertible-to-charN-t-view*@<char32_t> V>
-  template<bool Const>
-  class as_char32_t_view<V>::@*iterator*@
-      : public iterator_interface<@*iterator-to-tag-t*@<ranges::iterator_t<@*maybe-const*@<Const, V>>>, char32_t, char32_t, void, ptrdiff_t> {
-  public:
-    using reference_type = char32_t;
-
-  private:
-    using @*iterator-type*@ = ranges::iterator_t<@*maybe-const*@<Const, V>>; // @*exposition only*@
-
-    friend access;
-
-    constexpr @*iterator-type*@& base_reference() noexcept { return it_; } // @*exposition only*@
-    constexpr @*iterator-type*@ base_reference() const { return it_; } // @*exposition only*@
-
-    @*iterator-type*@ it_ = @*iterator-type*@(); // @*exposition only*@
-
-  public:
-    constexpr @*iterator*@() = default;
-    constexpr @*iterator*@(@*iterator-type*@ it) : it_(move(it)) {}
-
-    constexpr reference_type operator*() const { return *it_; }
-  };
-
-  template<@*convertible-to-charN-t-view*@<char32_t> V>
-  template<bool Const>
-  class as_char32_t_view<V>::@*sentinel*@ {
-    using @*base*@ = @*maybe-const*@<Const, V>; // @*exposition only*@
-    using @*sentinel-type*@ = ranges::sentinel_t<@*base*@>; // @*exposition only*@
-
-    @*sentinel-type*@ end_ = @*sentinel-type*@(); // @*exposition only*@
-
-  public:
-    constexpr @*sentinel*@() = default;
-    constexpr explicit @*sentinel*@(@*sentinel-type*@ end) : end_(move(end)) {}
-    constexpr @*sentinel*@(@*sentinel*@<!Const> i) requires Const && convertible_to<ranges::sentinel_t<V>, ranges::sentinel_t<@*base*@>>;
-
-    constexpr @*sentinel-type*@ base() const { return end_; }
-
-    template<bool OtherConst>
-      requires sentinel_for<@*sentinel-type*@, ranges::iterator_t<@*maybe-const*@<OtherConst, V>>>
-    friend constexpr bool operator==(const @*iterator*@<OtherConst>& x, const @*sentinel*@& y) {
-      return x.it_ == y.end_;
-    }
-
-    template<bool OtherConst>
-      requires sized_sentinel_for<@*sentinel-type*@, ranges::iterator_t<@*maybe-const*@<OtherConst, V>>>
-    friend constexpr ranges::range_difference_t<@*maybe-const*@<OtherConst, V>> operator-(const @*iterator*@<OtherConst>& x, const @*sentinel*@& y) {
-      return x.it_ - y.end_;
-    }
-
-    template<bool OtherConst>
-      requires sized_sentinel_for<@*sentinel-type*@, ranges::iterator_t<@*maybe-const*@<OtherConst, V>>>
-    friend constexpr ranges::range_difference_t<@*maybe-const*@<OtherConst, V>> operator-(const @*sentinel*@& y, const @*iterator*@<OtherConst>& x) {
-      return y.end_ - x.it_;
-    }
-  };
-
-  template<class R>
-  as_char32_t_view(R&&) -> as_char32_t_view<views::all_t<R>>;
-
-  inline constexpr @*unspecified*@ as_char8_t;
-
+  inline constexpr @*unspecified*@ as_char8_t; 
+                                               
   inline constexpr @*unspecified*@ as_char16_t;
-
+                                               
   inline constexpr @*unspecified*@ as_char32_t;
-
-}
-
-namespace std::ranges {
-
-  template<class V>
-  inline constexpr bool enable_borrowed_range<std::uc::as_char8_t_view<V>> = enable_borrowed_range<V>;
-
-  template<class V>
-  inline constexpr bool enable_borrowed_range<std::uc::as_char16_t_view<V>> = enable_borrowed_range<V>;
-
-  template<class V>
-  inline constexpr bool enable_borrowed_range<std::uc::as_char32_t_view<V>> = enable_borrowed_range<V>;
-
 }
 ```
 
-`char8_view` produces a view of `char8_t` elements from another view.
-`char16_view` produces a view of `char16_t` elements from another view.
-`char32_view` produces a view of `char32_t` elements from another view. Let
-`charN_view` denote any one of the views `char8_view`, `char16_view`, and
-`char32_view`.
-
 The names `as_char8_t`, `as_char16_t`, and `as_char32_t` denote range adaptor
-objects ([range.adaptor.object]). `as_char8_t` produces `char8_view`s,
-`as_char16_t` produces `char16_view`s, and `as_char32_t` produces
-`char32_view`s. Let `as_charN_t` denote any one of `as_char8_t`,
-`as_char16_t`, and `as_char32_t`, and let `V` denote the `charN_view`
-associated with that object. Let `E` be an expression and let `T` be
-`remove_cvref_t<decltype((E))>`. Let `F` be the `format` enumerator
-associated with `as_charN_t`. If `decltype((E))` does not model
-`utf_pointer<T>` and if `charN_view(E)` is ill-formed, `as_charN_t(E)` is
-ill-formed. The expression `as_charN_t(E)` is expression-equivalent to:
+objects ([range.adaptor.object]). Let `as_charN_t` denote any one of
+`as_char8_t`, `as_char16_t`, and `as_char32_t`. Let `Char` be the corresponding
+character type for `as_charN_t`, let `E` be an expression and let `T` be
+`remove_cvref_t<decltype((E))>`. If `ranges::range_reference_t<T>` does not
+model `convertible_to<Char>`, `as_charN_t(E)` is ill-formed. The expression
+`as_charN_t(E)` is expression-equivalent to:
 
 - If `T` is a specialization of `empty_view` ([range.empty.view]), then
-  `empty_view<@*format-to-type-t*@<F>>{}`.
+  `empty_view<Char>{}`.
 
 - Otherwise, if `T` is an array type of known bound, then:
 
   - If the array extent is nonzero and the last element of the array is zero,
     then
-    `V(std::ranges::subrange(std::ranges::begin(E), --std::ranges::end(E)))`
+    `ranges::transform_view(std::ranges::subrange(std::ranges::begin(E), --std::ranges::end(E)), @*implicit-cast-to*@<Char>{})`
   - Otherwise,
-    `V(std::ranges::subrange(std::ranges::begin(E), std::ranges::end(E)))`
+    `ranges::transform_view(std::ranges::subrange(std::ranges::begin(E), std::ranges::end(E)), @*implicit-cast-to*@<Char>{})`
 
-- Otherwise, `V(std::views::all(E))`.
+- Otherwise, `ranges::transform_view(std::views::all(E), @*implicit-cast-to*@<Char>{})`
+
 
 \[Example 1:
 ```c++
@@ -5974,23 +5606,6 @@ all-or-nothing nature of deduction guides. So we need separate `to_utfN_view`s
 and separate `as_charN_t_view`s instead of having them simply be alias
 templates for a hypothetical generic `to_utf_view<ToType>` or
 `as_charN_t_view<ToType>`, respectively.
-
-## Why `as_charN_t_view` is not implemented in terms of `transform_view`
-
-Because `transform_view` [cannot](https://stackoverflow.com/a/76789448) be a
-`borrowed_range`, whereas `as_charN_t_view` can.
-
-[@P3117R0] attempted to extend `transform_view` to be conditionally borrowed,
-but its authors are not pursuing it further following
-[concerns](https://github.com/cplusplus/papers/issues/1779#issuecomment-2014160066)
-raised by SG9 in Tokyo 2024.
-
-A previous revision of this paper proposed for standardization a
-`project_view<V, F>` view that would be like `transform_view` except that the
-transformation function would be an NTTP, enabling `project_view` to be a
-`borrowed_range`. However, this was removed because the NTTP template
-parameter prevents us from providing a `views::all_t` deduction guide as
-described in the previous section.
 
 ## Why `utf_view` always transcodes, even in UTF-N to UTF-N cases
 

--- a/src/beman/utf_view/CMakeLists.txt
+++ b/src/beman/utf_view/CMakeLists.txt
@@ -16,7 +16,8 @@ target_include_directories(
     $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}/${CMAKE_LOWER_PROJECT_NAME}> # <prefix>/include/beman/utf_view
 )
 
-target_link_libraries(beman_utf_view INTERFACE beman::iterator_interface)
+target_link_libraries(
+  beman_utf_view INTERFACE beman::transform_view_26)
 
 install(
   TARGETS beman_utf_view

--- a/tests/beman/utf_view/code_unit_view.t.cpp
+++ b/tests/beman/utf_view/code_unit_view.t.cpp
@@ -9,6 +9,7 @@
 #include <beman/utf_view/detail/constexpr_unless_msvc.hpp>
 #include <framework.hpp>
 #include <test_iterators.hpp>
+#include <cstdint>
 #include <ranges>
 #include <string_view>
 
@@ -17,68 +18,83 @@ namespace beman::utf_view::tests {
 static_assert(
   std::input_iterator<
     std::ranges::iterator_t<
-      as_char8_t_view<
-        std::ranges::subrange<test_input_iterator<char>, std::default_sentinel_t>>>>);
-
+        decltype(
+          std::declval<
+              std::ranges::subrange<test_input_iterator<char>, std::default_sentinel_t>>()
+          | as_char8_t)>>);
 static_assert(
   std::input_iterator<
     std::ranges::iterator_t<
-      as_char8_t_view<
-        std::ranges::subrange<test_comparable_input_iterator<char>,
-                              std::default_sentinel_t>>>>);
-
+        decltype(
+          std::declval<
+              std::ranges::subrange<
+                  test_comparable_input_iterator<char>, std::default_sentinel_t>>()
+          | as_char8_t)>>);
 static_assert(
   std::input_iterator<
     std::ranges::iterator_t<
-      as_char8_t_view<
-        std::ranges::subrange<test_copyable_input_iterator<char>,
-                              std::default_sentinel_t>>>>);
+        decltype(
+          std::declval<
+              std::ranges::subrange<
+                  test_copyable_input_iterator<char>, std::default_sentinel_t>>()
+          | as_char8_t)>>);
 static_assert(
   !std::forward_iterator<
     std::ranges::iterator_t<
-      as_char8_t_view<
-        std::ranges::subrange<test_copyable_input_iterator<char>,
-                              std::default_sentinel_t>>>>);
+        decltype(
+          std::declval<
+              std::ranges::subrange<
+                  test_copyable_input_iterator<char>, std::default_sentinel_t>>()
+          | as_char8_t)>>);
 
 static_assert(
   std::forward_iterator<
     std::ranges::iterator_t<
-      as_char8_t_view<
-        std::ranges::subrange<test_forward_iterator<char>,
-                              std::default_sentinel_t>>>>);
+        decltype(
+          std::declval<
+              std::ranges::subrange<
+                  test_forward_iterator<char>, std::default_sentinel_t>>()
+          | as_char8_t)>>);
 static_assert(
   std::forward_iterator<
-    std::ranges::sentinel_t<
-      as_char8_t_view<
-        std::ranges::subrange<test_forward_iterator<char>,
-                              test_forward_iterator<char>>>>>);
+    std::ranges::iterator_t<
+        decltype(
+          std::declval<
+              std::ranges::subrange<
+                  test_forward_iterator<char>, test_forward_iterator<char>>>()
+          | as_char8_t)>>);
+
 static_assert(
   std::bidirectional_iterator<
     std::ranges::iterator_t<
-      as_char8_t_view<
-        std::ranges::subrange<test_bidi_iterator<char>,
-                              std::default_sentinel_t>>>>);
+        decltype(
+          std::declval<
+              std::ranges::subrange<test_bidi_iterator<char>, std::default_sentinel_t>>()
+          | as_char8_t)>>);
 static_assert(
   std::bidirectional_iterator<
     std::ranges::sentinel_t<
-      as_char8_t_view<
-        std::ranges::subrange<test_bidi_iterator<char>,
-                              test_bidi_iterator<char>>>>>);
+        decltype(
+          std::declval<
+              std::ranges::subrange<test_bidi_iterator<char>, test_bidi_iterator<char>>>()
+          | as_char8_t)>>);
 
 static_assert(
   std::random_access_iterator<
     std::ranges::iterator_t<
-      as_char8_t_view<
-        std::ranges::subrange<test_random_access_iterator<char>,
-                              std::default_sentinel_t>>>>);
+        decltype(
+          std::declval<
+              std::ranges::subrange<
+                  test_random_access_iterator<char>, std::default_sentinel_t>>()
+          | as_char8_t)>>);
 static_assert(
   std::random_access_iterator<
     std::ranges::sentinel_t<
-      as_char8_t_view<
-        std::ranges::subrange<test_random_access_iterator<char>,
-                              test_random_access_iterator<char>>>>>);
-
-// TODO: Comprehensive testing for `code_unit_view`
+        decltype(
+          std::declval<
+              std::ranges::subrange<
+                  test_random_access_iterator<char>, test_random_access_iterator<char>>>()
+          | as_char8_t)>>);
 
 constexpr bool smoke_test() {
   std::string_view foo{"foo"};
@@ -91,8 +107,36 @@ constexpr bool smoke_test() {
   return true;
 }
 
+constexpr bool special_case_test() {
+  std::ranges::empty_view<std::uint8_t> empty_int_view{};
+  auto empty_char8_view{empty_int_view | as_char8_t};
+  static_assert(
+      std::is_same_v<decltype(empty_char8_view), std::ranges::empty_view<char8_t>>);
+  auto char_string_literal_as_char8_view{"foo" | as_char8_t};
+  auto char_string_literal_as_char8_view_it{char_string_literal_as_char8_view.begin()};
+  if (*char_string_literal_as_char8_view_it != u8'f') {
+    return false;
+  }
+  ++char_string_literal_as_char8_view_it;
+  if (*char_string_literal_as_char8_view_it != u8'o') {
+    return false;
+  }
+  ++char_string_literal_as_char8_view_it;
+  if (*char_string_literal_as_char8_view_it != u8'o') {
+    return false;
+  }
+  ++char_string_literal_as_char8_view_it;
+  if (char_string_literal_as_char8_view_it != char_string_literal_as_char8_view.end()) {
+    return false;
+  }
+  return true;
+}
+
 CONSTEXPR_UNLESS_MSVC bool code_unit_view_test() {
   if (!smoke_test()) {
+    return false;
+  }
+  if (!special_case_test()) {
     return false;
   }
   return true;

--- a/tests/beman/utf_view/readme_examples.t.cpp
+++ b/tests/beman/utf_view/readme_examples.t.cpp
@@ -10,6 +10,7 @@
 #include <beman/utf_view/null_term.hpp>
 #include <beman/utf_view/to_utf_view.hpp>
 #include <filesystem>
+#include <functional>
 #include <iterator>
 #include <optional>
 #include <ranges>


### PR DESCRIPTION
Since ea9530e23649805dafe52d229cb8468c1eea9d04 removed the unnecessary depenedency of to_utfN_view on iterator_interface, its only remaining use was in code_unit_view. Furthermore, the original reason that the code unit views wer not implemented in terms of transform_view was that transform_view was not conditionally borrowed; however, P3117 provided a way of making transform_view conditionally borrowed, and Zach Laine provided an implementation, making it viable to use transform_view for the code unit views. This commit implements that change, removes the dependency on iterator_interface, and adds a dependency on transform_view.