### PR TITLE
Rename UTF_VIEW_BUILD_TESTING -> BEMAN_UTF_VIEW_BUILD_TESTING

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -11,7 +11,7 @@ project(beman.utf_view CXX)
 include(FetchContent)
 
 option(
-    UTF_VIEW_BUILD_TESTING
+    BEMAN_UTF_VIEW_BUILD_TESTING
     "Enable building tests and test infrastructure. Default: ON. Values: { ON, OFF }."
     ${PROJECT_IS_TOP_LEVEL}
 )
@@ -37,7 +37,7 @@ if (BEMAN_UTF_VIEW_BUILD_PAPER)
   add_subdirectory(paper)
 endif()
 
-if (UTF_VIEW_BUILD_TESTING)
+if (BEMAN_UTF_VIEW_BUILD_TESTING)
     enable_testing()
     add_subdirectory(tests/beman/utf_view)
 endif()

--- a/README.md
+++ b/README.md
@@ -130,7 +130,7 @@ This excerpt from the project's CI script provides an example of building the pr
 
     mkdir "$checkout/build"
     cd "$checkout/build"
-    cmake .. -DCMAKE_BUILD_TYPE=Debug -DCMAKE_CXX_STANDARD=23 -DUTF_VIEW_BUILD_TESTING=On "$@"
+    cmake .. -DCMAKE_BUILD_TYPE=Debug -DCMAKE_CXX_STANDARD=23 -DBEMAN_UTF_VIEW_BUILD_TESTING=On "$@"
     cmake --build . --parallel
     ctest -C Debug
 

--- a/ci.sh
+++ b/ci.sh
@@ -7,7 +7,7 @@ function main() {
     local checkout="$PWD"
     mkdir "$checkout/build"
     cd "$checkout/build"
-    cmake .. -DCMAKE_BUILD_TYPE=Debug -DCMAKE_CXX_STANDARD=23 -DUTF_VIEW_BUILD_TESTING=On "$@"
+    cmake .. -DCMAKE_BUILD_TYPE=Debug -DCMAKE_CXX_STANDARD=23 -DBEMAN_UTF_VIEW_BUILD_TESTING=On "$@"
     cmake --build . --parallel
     export ASAN_OPTIONS=alloc_dealloc_mismatch=0 # https://github.com/llvm/llvm-project/issues/59432
     ctest -C Debug


### PR DESCRIPTION
This change makes it more consistent with BEMAN_UTF_VIEW_BUILD_PAPER and is the convention used in exemplar.