### PR TITLE
P3705 unchecked_take_before design alternative

### DIFF
--- a/paper/P3705.md
+++ b/paper/P3705.md
@@ -112,7 +112,14 @@ other parameter in the standard library that takes an iterator takes it by value
 we still need to take input iterators by reference here, we allow the common case to be
 consistent and treat the edge case as an edge case.
 
-## exposition-only helper concept `@*default-initializable-and-equality-comparable-iter-value*@`
+Finally, we could also simply drop `null_sentinel` entirely, only standardize `null_term`,
+and implement `null_term` in terms of `unchecked_take_before`. Note that at the time of
+writing, there is no paper proposing `unchecked_take_before`, so that would also need to
+be written if we want to take that direction.
+
+## Sentinel-based design
+
+### Exposition-only helper concept `@*default-initializable-and-equality-comparable-iter-value*@`
 
 ```cpp
 namespace std {
@@ -125,9 +132,9 @@ namespace std {
 }
 ```
 
-## null_sentinel pass-by-value design
+### `null_sentinel` pass-by-value design
 
-### Null sentinel
+#### Null sentinel
 
 ```cpp
 namespace std {
@@ -146,7 +153,7 @@ namespace std {
 }
 ```
 
-### Operations
+#### Operations
 
 ```c++
 template<input_iterator I>
@@ -168,9 +175,9 @@ Effects:
 
 Equivalent to `return *it == iter_value_t<I>{};`.
 
-## null_sentinel pass-by-reference design
+### `null_sentinel` pass-by-reference design
 
-### Null sentinel
+#### Null sentinel
 
 ```cpp
 namespace std {
@@ -186,7 +193,7 @@ namespace std {
 }
 ```
 
-### Operations
+#### Operations
 
 ```c++
 template<input_iterator I>
@@ -198,7 +205,7 @@ Effects:
 
 Equivalent to `return *it == iter_value_t<I>{};`.
 
-## null_term CPO
+### `null_term` CPO
 
 ```cpp
 namespace std {
@@ -211,6 +218,38 @@ namespace std {
 The name `null_term` denotes a customization point object ([customization.point.object]).
 Given a subexpression `E`, the expression `null_term(E)` is expression-equivalent to
 `ranges::subrange(E, null_sentinel)`.
+
+## `unchecked_take_before`-based design
+
+### exposition-only helper concept `@*default-initializable-iter-value*@`
+
+```cpp
+namespace std {
+
+  template<class I>
+  concept @*default-initializable-iter-value*@ =
+    default_initializable<iter_value_t<I>>; // @*exposition only*@
+
+}
+```
+
+### `null_term` CPO
+
+```cpp
+namespace std {
+
+  inline constexpr @*unspecified*@ null_term;
+
+}
+```
+
+The name `null_term` denotes a customization point object ([customization.point.object]).
+Given a subexpression `E`, the expression `null_term(E)` is expression-equivalent to
+`subrange(E, unreachable_sentinel) | unchecked_take_before(iter_value_t<decltype(E)>{})`.
+
+Constraints:
+
+`@*default-inititializable-iter-value*@<E>` is `true`.
 
 # History
 
@@ -252,6 +291,7 @@ split out by Eddie Nolan.
 
 - Fix off-by-one in textual description in motivation section
 - Add example with argv and environ
+- Add `unchecked_take_before` design alternative
 
 ## Relevant Polls/Minutes
 


### PR DESCRIPTION
Add an option to remove the null_sentinel entirely and back null_term with unchecked_take_before.