### PR TITLE
Changes for P3705R2

### DIFF
--- a/paper/P3705.md
+++ b/paper/P3705.md
@@ -1,7 +1,7 @@
 ---
 title: "A Sentinel for Null-Terminated Strings"
-document: P3705R1
-date: 2025-06-16
+document: P3705R2
+date: 2025-06-18
 audience:
   - SG-9 Ranges
   - LEWG
@@ -64,12 +64,12 @@ constexpr std::string take_five(char const* long_string) {
 }
 ```
 
-It also introduces a `null_term` CPO for the common case of constructing the a subrange
-like the one in the above example:
+It also introduces a `null_term` CPO for the common case of constructing a subrange like
+the one in the above example:
 
 ```cpp
 constexpr std::string take_five(char const* long_string) {
-  return std::string{std::from_range, std::null_term(long_string) | std::views::take(5)};
+  return std::string{std::from_range, std::views::null_term(long_string) | std::views::take(5)};
 }
 ```
 
@@ -86,8 +86,8 @@ For example, `null_term` can be used to iterate `argv` and `environ`. The follow
 extern char** environ;
 
 int main(int argc, char** argv) {
-  std::println("argv: {}", std::null_term(argv));
-  std::println("environ: {}", std::null_term(environ));
+  std::println("argv: {}", std::views::null_term(argv));
+  std::println("environ: {}", std::views::null_term(environ));
 }
 ```
 
@@ -99,27 +99,54 @@ argv: ["./test", "corge"]
 environ: ["FOO=bar", "BAZ=quux"]
 ```
 
-# Design Alternatives
+# Naming discussion
 
-This paper includes two alternatives for the sentinel: one that always passes the iterator
-to the equality operator by reference, and one that passes by reference for input
-iterators and by value otherwise. (Input iterators must be passed by reference here
-because they are allowed to be noncopyable.)
+## Bad names
 
-The argument for the by-reference design is that it's simpler. The argument for the
-by-value design is that it's more consistent, since, to the author's knowledge, every
-other parameter in the standard library that takes an iterator takes it by value; although
-we still need to take input iterators by reference here, we allow the common case to be
-consistent and treat the edge case as an edge case.
+### `c_str`
 
-Finally, we could also simply drop `null_sentinel` entirely, only standardize `null_term`,
-and implement `null_term` in terms of `unchecked_take_before`. Note that at the time of
-writing, there is no paper proposing `unchecked_take_before`, so that would also need to
-be written if we want to take that direction.
+`range-v3`
+[provides](https://ericniebler.github.io/range-v3/structranges_1_1views_1_1c__str__fn.html)
+similar functionality to `null_term` using the name `c_str`-- unlike `null_term`, `c_str`
+only works with `char`, `wchar_t`, and so forth.
 
-## Sentinel-based design
+The name `c_str` would not make sense here because, for example, `std::views::c_str(argv)`
+is nonsensical and misleading as to what the range is doing (terminating the sequence of
+strings rather than terminating the strings themselves).
 
-### Exposition-only helper concept `@*default-initializable-and-equality-comparable-iter-value*@`
+### `zstring_sentinel` and `zstring`
+
+An example from Barry Revzin's [@P2210R2] provides similar functionality under the names
+`zstring_sentinel` and `zstring`.
+
+I dislike this name for similar reasons as `c_str`. `argv` is not a "string."
+
+Additionally, it invites confusion with [@P3655R1] `zstring_view`.
+
+## Good names
+
+### Status quo: `null_sentinel` and `null_term`
+
+The advantages of these names are that they are terse, they do not include the word
+"string," and the value-initialized `iter_value_t` value is referred to as "null," which
+reflects the language we use in the standard ("null terminated byte string," "null
+terminated multibyte string," "null terminated character sequence," "null pointer")
+
+### `zero_termination_sentinel`
+
+This is used by think-cell's
+[implementation](https://github.com/think-cell/think-cell-library/blob/main/tc%2Frange%2Fmeta.h#L248)
+of this utility. I like it slightly less because it's more verbose but also consider it
+acceptable.
+
+### Your suggestion here
+
+This is not an exhaustive list.
+
+
+# Wording
+
+## Exposition-only helper concept `@*default-initializable-and-equality-comparable-iter-value*@`
 
 ```cpp
 namespace std {
@@ -132,52 +159,7 @@ namespace std {
 }
 ```
 
-### `null_sentinel` pass-by-value design
-
-#### Null sentinel
-
-```cpp
-namespace std {
-
-  struct null_sentinel_t {
-    template<input_iterator I>
-      requires (not forward_iterator<I>) && @*default-initializable-and-equality-comparable-iter-value*@<I>
-    friend constexpr bool operator==(I const& it, null_sentinel_t);
-    template<forward_iterator I>
-      requires @*default-initializable-and-equality-comparable-iter-value*@<I>
-    friend constexpr bool operator==(I it, null_sentinel_t);
-  };
-
-  inline constexpr null_sentinel_t null_sentinel;
-
-}
-```
-
-#### Operations
-
-```c++
-template<input_iterator I>
-  requires (not forward_iterator<I>) && @*default-initializable-and-equality-comparable-iter-value*@<I>
-friend constexpr bool operator==(I const& it, null_sentinel_t);
-```
-
-Effects:
-
-Equivalent to `return *it == iter_value_t<I>{};`.
-
-```c++
-template<forward_iterator I>
-  requires @*default-initializable-and-equality-comparable-iter-value*@<I>
-friend constexpr bool operator==(I it, null_sentinel_t);
-```
-
-Effects:
-
-Equivalent to `return *it == iter_value_t<I>{};`.
-
-### `null_sentinel` pass-by-reference design
-
-#### Null sentinel
+## Null sentinel
 
 ```cpp
 namespace std {
@@ -193,7 +175,7 @@ namespace std {
 }
 ```
 
-#### Operations
+### Operations
 
 ```c++
 template<input_iterator I>
@@ -205,10 +187,10 @@ Effects:
 
 Equivalent to `return *it == iter_value_t<I>{};`.
 
-### `null_term` CPO
+## `null_term` CPO
 
 ```cpp
-namespace std {
+namespace std::views {
 
   inline constexpr @*unspecified*@ null_term;
 
@@ -219,43 +201,17 @@ The name `null_term` denotes a customization point object ([customization.point.
 Given a subexpression `E`, the expression `null_term(E)` is expression-equivalent to
 `ranges::subrange(E, null_sentinel)`.
 
-## `unchecked_take_before`-based design
-
-### exposition-only helper concept `@*default-initializable-iter-value*@`
+## Feature test macro
 
 ```cpp
-namespace std {
-
-  template<class I>
-  concept @*default-initializable-iter-value*@ =
-    default_initializable<iter_value_t<I>>; // @*exposition only*@
-
-}
+#define __cpp_lib_ranges_null_sentinel 202506L
 ```
-
-### `null_term` CPO
-
-```cpp
-namespace std {
-
-  inline constexpr @*unspecified*@ null_term;
-
-}
-```
-
-The name `null_term` denotes a customization point object ([customization.point.object]).
-Given a subexpression `E`, the expression `null_term(E)` is expression-equivalent to
-`subrange(E, unreachable_sentinel) | unchecked_take_before(iter_value_t<decltype(E)>{})`.
-
-Constraints:
-
-`@*default-inititializable-iter-value*@<E>` is `true`.
 
 # History
 
 ## Changelog
 
-This proposal was originally written by Zach Laine as part of P2728, then updated and
+This proposal was originally written by Zach Laine as part of [@P2728R0], then updated and
 split out by Eddie Nolan.
 
 ### Changes since P2728R1
@@ -293,7 +249,37 @@ split out by Eddie Nolan.
 - Add example with argv and environ
 - Add `unchecked_take_before` design alternative
 
+### Changes since P3705R1
+
+- Remove `unchecked_take_before` and pass-by-value design alternatives
+- Add polls and minutes from Sofia 2025 SG9 review
+- Move `null_term` to namespace `std::views`
+- Add feature test macro
+- Add naming discussion
+
 ## Relevant Polls/Minutes
+
+### SG9 review of P3705R1 on 2025-06-18 during Sofia 2025
+
+- [Minutes](https://wiki.edg.com/bin/view/Wg21sofia2025/NotesSG9P3705R0)
+
+__POLL:__ We would like something like the proposed `null_sentinel` regardless of the addition of a hypothetical `unchecked_take_before` view that may come in the future.
+
+__Outcome:__ No objection to unanimous consent
+
+__POLL:__ Always pass the iterator by reference to `operator==`, move `null_term` to namespace `std::views`, add a discussion about alternative names, and forward P3705R1 with those changes to LEWG for inclusion in C++29.
+
+|SF|F|N|A|SA|
+|-|-|-|-|-|
+|9|7|0|0|0|
+
+__# Of Authors:__ 1
+
+__Author's Position:__ SF
+
+__Attendance:__ 18 (2 abstentions)
+
+__Outcome:__ Unanimous consent
 
 ### SG9 review of D2728R4 on 2023-06-12 during Varna 2023
 


### PR DESCRIPTION
- Remove `unchecked_take_before` and pass-by-value design alternatives
- Add polls and minutes from Sofia 2025 SG9 review
- Move `null_term` to namespace `std::views`
- Add feature test macro
- Add naming discussion