### PR TITLE
P3705: Initialization fixes

### DIFF
--- a/paper/P3705.md
+++ b/paper/P3705.md
@@ -74,9 +74,9 @@ constexpr std::string take_five(char const* long_string) {
 ```
 
 The sentinel type matches any iterator position `it` at which `*it` is equal to a
-default-constructed object of type `iter_value_t<I>`. This works for null-terminated
+value-initialized object of type `iter_value_t<I>`. This works for null-terminated
 strings, but can also serve as the sentinel for any range terminated by a
-default-constructed value.
+value-initialized value.
 
 For example, `null_term` can be used to iterate `argv` and `environ`. The following program demonstrates this:
 
@@ -185,7 +185,7 @@ friend constexpr bool operator==(I const& it, null_sentinel_t);
 
 Effects:
 
-Equivalent to `return *it == iter_value_t<I>{};`.
+Equivalent to `return *it == iter_value_t<I>();`.
 
 ## `null_term` CPO
 
@@ -258,6 +258,7 @@ split out by Eddie Nolan.
 - Move `null_term` to namespace `std::views`
 - Add feature test macro
 - Add naming discussion
+- Use `iter_value_t<I>()` over `iter_value_t<I>{}` to avoid `initializer_list` interaction
 
 ## Relevant Polls/Minutes
 


### PR DESCRIPTION
The intent is to value-initialize the iter_value_t. However:

- The motivation section referred to it as being "default-constructed"
- The implementation of the operation used direct-list-initialization from an empty initializer list instead of value-initialization

This commit updates the paper to use value-initialization everywhere.