### PR TITLE
Fix missing syntax highlighting in two code blocks

### DIFF
--- a/paper/P2728.md
+++ b/paper/P2728.md
@@ -298,7 +298,7 @@ to_utf8_view(R &&) -> to_utf8_view<views::all_t<R>>;
 
 An alternative design is possible where the `to_utfN_views` are defined in terms of a `to_utf_view` with a format NTTP, as was done in a previous version of this paper:
 
-```
+```cpp
   template<format Format, class R>
   to_utf_view(R &&) -> to_utf_view<Format, views::all_t<R>>;
 
@@ -1171,7 +1171,7 @@ underlying range is empty.
 
 ## Code unit adaptors
 
-```
+```cpp
 namespace std::ranges::views {
 
   template<class T>


### PR DESCRIPTION
<!--
Please take note of the following when contributing:
- Our code of conduct: https://github.com/bemanproject/beman/blob/main/docs/code_of_conduct.md
- The Beman Standard: https://github.com/bemanproject/beman/blob/main/docs/beman_standard.md
-->
