### PR TITLE
Fix find_package to use the correct beman.transform_view name

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -39,7 +39,7 @@ option(
     ${PROJECT_IS_TOP_LEVEL}
 )
 
-find_package(beman::transform_view REQUIRED)
+find_package(beman.transform_view REQUIRED)
 
 add_subdirectory(src/beman/utf_view)
 


### PR DESCRIPTION
This is a follow up of https://github.com/bemanproject/utf_view/issues/188.