### PR TITLE
Update lockfile.json with the correct beman.transform_view spelling

### DIFF
--- a/lockfile.json
+++ b/lockfile.json
@@ -2,7 +2,7 @@
   "dependencies": [
     {
       "name": "transform_view",
-      "package_name": "beman::transform_view",
+      "package_name": "beman.transform_view",
       "git_repository": "https://github.com/bemanproject/transform_view.git",
       "git_tag": "82e982882c79004ce748b32c3bd6481def185bb5"
     }


### PR DESCRIPTION
21845c1d8bcdd176f5557a7c4e66773a72c0d5f6 didn't update this file, which broke the build.

<!--
Please take note of the following when contributing:
- Our code of conduct: https://github.com/bemanproject/beman/blob/main/docs/code_of_conduct.md
- The Beman Standard: https://github.com/bemanproject/beman/blob/main/docs/beman_standard.md
-->
