### PR TITLE
Improve accuracy of copyright banners

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,6 @@
 # SPDX-License-Identifier: BSL-1.0
 
-#   Copyright Eddie Nolan and Jonathan Wakely 2023 - 2025.
+#   Copyright Eddie Nolan 2023 - 2026.
 # Distributed under the Boost Software License, Version 1.0.
 #    (See accompanying file LICENSE.txt or copy at
 #          https://www.boost.org/LICENSE_1_0.txt)

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 <!--
 SPDX-License-Identifier: BSL-1.0
 
-  Copyright Eddie Nolan and Jonathan Wakely 2023 - 2025.
+  Copyright Eddie Nolan 2023 - 2026.
 Distributed under the Boost Software License, Version 1.0.
    (See accompanying file LICENSE.txt or copy at
          https://www.boost.org/LICENSE_1_0.txt)

--- a/examples/readme_examples.cpp
+++ b/examples/readme_examples.cpp
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: BSL-1.0
 
-//   Copyright Eddie Nolan and Jonathan Wakely 2023 - 2025.
+//   Copyright Eddie Nolan 2023 - 2026.
 // Distributed under the Boost Software License, Version 1.0.
 //    (See accompanying file LICENSE.txt or copy at
 //          https://www.boost.org/LICENSE_1_0.txt)

--- a/include/beman/utf_view/code_unit_view.hpp
+++ b/include/beman/utf_view/code_unit_view.hpp
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: BSL-1.0
 
-//   Copyright Eddie Nolan and Jonathan Wakely 2023 - 2025.
+//   Copyright Eddie Nolan 2023 - 2026.
 // Distributed under the Boost Software License, Version 1.0.
 //    (See accompanying file LICENSE.txt or copy at
 //          https://www.boost.org/LICENSE_1_0.txt)

--- a/include/beman/utf_view/detail/concepts.hpp
+++ b/include/beman/utf_view/detail/concepts.hpp
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: BSL-1.0
 
-//   Copyright Eddie Nolan and Jonathan Wakely 2023 - 2025.
+//   Copyright Eddie Nolan 2023 - 2025.
 // Distributed under the Boost Software License, Version 1.0.
 //    (See accompanying file LICENSE.txt or copy at
 //          https://www.boost.org/LICENSE_1_0.txt)

--- a/include/beman/utf_view/detail/constant_wrapper_polyfill.hpp
+++ b/include/beman/utf_view/detail/constant_wrapper_polyfill.hpp
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: BSL-1.0
 
-//   Copyright Eddie Nolan and Jonathan Wakely 2023 - 2025.
+//   Copyright Eddie Nolan 2026.
 // Distributed under the Boost Software License, Version 1.0.
 //    (See accompanying file LICENSE.txt or copy at
 //          https://www.boost.org/LICENSE_1_0.txt)

--- a/include/beman/utf_view/detail/constexpr_unless_msvc.hpp
+++ b/include/beman/utf_view/detail/constexpr_unless_msvc.hpp
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: BSL-1.0
 
-//   Copyright Eddie Nolan and Jonathan Wakely 2023 - 2025.
+//   Copyright Eddie Nolan 2023 - 2025.
 // Distributed under the Boost Software License, Version 1.0.
 //    (See accompanying file LICENSE.txt or copy at
 //          https://www.boost.org/LICENSE_1_0.txt)

--- a/include/beman/utf_view/detail/fake_inplace_vector.hpp
+++ b/include/beman/utf_view/detail/fake_inplace_vector.hpp
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: BSL-1.0
 
-//   Copyright Eddie Nolan and Jonathan Wakely 2023 - 2025.
+//   Copyright Eddie Nolan 2025 - 2026.
 // Distributed under the Boost Software License, Version 1.0.
 //    (See accompanying file LICENSE.txt or copy at
 //          https://www.boost.org/LICENSE_1_0.txt)

--- a/include/beman/utf_view/endian_view.hpp
+++ b/include/beman/utf_view/endian_view.hpp
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: BSL-1.0
 
-//   Copyright Eddie Nolan and Jonathan Wakely 2023 - 2025.
+//   Copyright Eddie Nolan 2026.
 // Distributed under the Boost Software License, Version 1.0.
 //    (See accompanying file LICENSE.txt or copy at
 //          https://www.boost.org/LICENSE_1_0.txt)

--- a/include/beman/utf_view/null_term.hpp
+++ b/include/beman/utf_view/null_term.hpp
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: BSL-1.0
 
-//   Copyright Eddie Nolan and Jonathan Wakely 2023 - 2025.
+//   Copyright Eddie Nolan 2023 - 2025.
 // Distributed under the Boost Software License, Version 1.0.
 //    (See accompanying file LICENSE.txt or copy at
 //          https://www.boost.org/LICENSE_1_0.txt)

--- a/include/beman/utf_view/to_utf_view.hpp
+++ b/include/beman/utf_view/to_utf_view.hpp
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: BSL-1.0
 
-//   Copyright Eddie Nolan and Jonathan Wakely 2023 - 2025.
+//   Copyright Eddie Nolan and Jonathan Wakely 2023 - 2026.
 // Distributed under the Boost Software License, Version 1.0.
 //    (See accompanying file LICENSE.txt or copy at
 //          https://www.boost.org/LICENSE_1_0.txt)

--- a/papers/CMakeLists.txt
+++ b/papers/CMakeLists.txt
@@ -1,6 +1,6 @@
 # SPDX-License-Identifier: BSL-1.0
 
-#   Copyright Eddie Nolan and Jonathan Wakely 2023 - 2025.
+#   Copyright Eddie Nolan 2023 - 2026.
 # Distributed under the Boost Software License, Version 1.0.
 #    (See accompanying file LICENSE.txt or copy at
 #          https://www.boost.org/LICENSE_1_0.txt)

--- a/src/beman/utf_view/CMakeLists.txt
+++ b/src/beman/utf_view/CMakeLists.txt
@@ -1,6 +1,6 @@
 # SPDX-License-Identifier: BSL-1.0
 
-#   Copyright Eddie Nolan and Jonathan Wakely 2023 - 2025.
+#   Copyright Eddie Nolan 2023 - 2026.
 # Distributed under the Boost Software License, Version 1.0.
 #    (See accompanying file LICENSE.txt or copy at
 #          https://www.boost.org/LICENSE_1_0.txt)

--- a/tests/beman/utf_view/CMakeLists.txt
+++ b/tests/beman/utf_view/CMakeLists.txt
@@ -1,6 +1,6 @@
 # SPDX-License-Identifier: BSL-1.0
 
-#   Copyright Eddie Nolan and Jonathan Wakely 2023 - 2025.
+#   Copyright Eddie Nolan 2023 - 2026.
 # Distributed under the Boost Software License, Version 1.0.
 #    (See accompanying file LICENSE.txt or copy at
 #          https://www.boost.org/LICENSE_1_0.txt)

--- a/tests/beman/utf_view/code_unit_view.t.cpp
+++ b/tests/beman/utf_view/code_unit_view.t.cpp
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: BSL-1.0
 
-//   Copyright Eddie Nolan and Jonathan Wakely 2023 - 2025.
+//   Copyright Eddie Nolan 2023 - 2026.
 // Distributed under the Boost Software License, Version 1.0.
 //    (See accompanying file LICENSE.txt or copy at
 //          https://www.boost.org/LICENSE_1_0.txt)

--- a/tests/beman/utf_view/detail/concepts.t.cpp
+++ b/tests/beman/utf_view/detail/concepts.t.cpp
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: BSL-1.0
 
-//   Copyright Eddie Nolan and Jonathan Wakely 2023 - 2025.
+//   Copyright Eddie Nolan 2023 - 2025.
 // Distributed under the Boost Software License, Version 1.0.
 //    (See accompanying file LICENSE.txt or copy at
 //          https://www.boost.org/LICENSE_1_0.txt)

--- a/tests/beman/utf_view/endian_view.t.cpp
+++ b/tests/beman/utf_view/endian_view.t.cpp
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: BSL-1.0
 
-//   Copyright Eddie Nolan and Jonathan Wakely 2023 - 2025.
+//   Copyright Eddie Nolan 2026.
 // Distributed under the Boost Software License, Version 1.0.
 //    (See accompanying file LICENSE.txt or copy at
 //          https://www.boost.org/LICENSE_1_0.txt)

--- a/tests/beman/utf_view/framework.cpp
+++ b/tests/beman/utf_view/framework.cpp
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: BSL-1.0
 
-//   Copyright Eddie Nolan and Jonathan Wakely 2023 - 2025.
+//   Copyright Eddie Nolan 2023 - 2025.
 // Distributed under the Boost Software License, Version 1.0.
 //    (See accompanying file LICENSE.txt or copy at
 //          https://www.boost.org/LICENSE_1_0.txt)

--- a/tests/beman/utf_view/framework.hpp
+++ b/tests/beman/utf_view/framework.hpp
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: BSL-1.0
 
-//   Copyright Eddie Nolan and Jonathan Wakely 2023 - 2025.
+//   Copyright Eddie Nolan 2023 - 2025.
 // Distributed under the Boost Software License, Version 1.0.
 //    (See accompanying file LICENSE.txt or copy at
 //          https://www.boost.org/LICENSE_1_0.txt)

--- a/tests/beman/utf_view/main.t.cpp
+++ b/tests/beman/utf_view/main.t.cpp
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: BSL-1.0
 
-//   Copyright Eddie Nolan and Jonathan Wakely 2023 - 2025.
+//   Copyright Eddie Nolan 2023 - 2025.
 // Distributed under the Boost Software License, Version 1.0.
 //    (See accompanying file LICENSE.txt or copy at
 //          https://www.boost.org/LICENSE_1_0.txt)

--- a/tests/beman/utf_view/null_term.t.cpp
+++ b/tests/beman/utf_view/null_term.t.cpp
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: BSL-1.0
 
-//   Copyright Eddie Nolan and Jonathan Wakely 2023 - 2025.
+//   Copyright Eddie Nolan 2023 - 2025.
 // Distributed under the Boost Software License, Version 1.0.
 //    (See accompanying file LICENSE.txt or copy at
 //          https://www.boost.org/LICENSE_1_0.txt)

--- a/tests/beman/utf_view/std_archetypes/exposition_only.hpp
+++ b/tests/beman/utf_view/std_archetypes/exposition_only.hpp
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: BSL-1.0
 
-//   Copyright Eddie Nolan and Jonathan Wakely 2023 - 2025.
+//   Copyright Eddie Nolan 2023 - 2025.
 // Distributed under the Boost Software License, Version 1.0.
 //    (See accompanying file LICENSE.txt or copy at
 //          https://www.boost.org/LICENSE_1_0.txt)

--- a/tests/beman/utf_view/std_archetypes/exposition_only.t.cpp
+++ b/tests/beman/utf_view/std_archetypes/exposition_only.t.cpp
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: BSL-1.0
 
-//   Copyright Eddie Nolan and Jonathan Wakely 2023 - 2025.
+//   Copyright Eddie Nolan 2023 - 2025.
 // Distributed under the Boost Software License, Version 1.0.
 //    (See accompanying file LICENSE.txt or copy at
 //          https://www.boost.org/LICENSE_1_0.txt)

--- a/tests/beman/utf_view/std_archetypes/iterator.hpp
+++ b/tests/beman/utf_view/std_archetypes/iterator.hpp
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: BSL-1.0
 
-//   Copyright Eddie Nolan and Jonathan Wakely 2023 - 2025.
+//   Copyright Eddie Nolan 2023 - 2025.
 // Distributed under the Boost Software License, Version 1.0.
 //    (See accompanying file LICENSE.txt or copy at
 //          https://www.boost.org/LICENSE_1_0.txt)

--- a/tests/beman/utf_view/std_archetypes/iterator.t.cpp
+++ b/tests/beman/utf_view/std_archetypes/iterator.t.cpp
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: BSL-1.0
 
-//   Copyright Eddie Nolan and Jonathan Wakely 2023 - 2025.
+//   Copyright Eddie Nolan 2023 - 2025.
 // Distributed under the Boost Software License, Version 1.0.
 //    (See accompanying file LICENSE.txt or copy at
 //          https://www.boost.org/LICENSE_1_0.txt)

--- a/tests/beman/utf_view/test_iterators.hpp
+++ b/tests/beman/utf_view/test_iterators.hpp
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: BSL-1.0
 
-//   Copyright Eddie Nolan and Jonathan Wakely 2023 - 2025.
+//   Copyright Eddie Nolan 2024 - 2025.
 // Distributed under the Boost Software License, Version 1.0.
 //    (See accompanying file LICENSE.txt or copy at
 //          https://www.boost.org/LICENSE_1_0.txt)

--- a/tests/beman/utf_view/to_utf_view.t.cpp
+++ b/tests/beman/utf_view/to_utf_view.t.cpp
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: BSL-1.0
 
-//   Copyright Eddie Nolan and Jonathan Wakely 2023 - 2025.
+//   Copyright Eddie Nolan 2023 - 2026.
 // Distributed under the Boost Software License, Version 1.0.
 //    (See accompanying file LICENSE.txt or copy at
 //          https://www.boost.org/LICENSE_1_0.txt)


### PR DESCRIPTION
Previously, these copyright banners were boilerplate across the entire repository, despite the fact that the years that the files were introduced differed and that code from Jonathan Wakely was only incorprated into include/beman/utf_view/to_utf_view.hpp.

This commit removes the Jonathan Wakely credit from all the banners except for that file, and updates the year ranges to reflect the time spans recorded by git for the commits that touch them.

<!--
Please take note of the following when contributing:
- Our code of conduct: https://github.com/bemanproject/beman/blob/main/docs/code_of_conduct.md
- The Beman Standard: https://github.com/bemanproject/beman/blob/main/docs/beman_standard.md
-->
