### PR TITLE
Remove iterator base() for input-only ranges

### DIFF
--- a/include/beman/utf_view/to_utf_view.hpp
+++ b/include/beman/utf_view/to_utf_view.hpp
@@ -330,7 +330,7 @@ private:
     current_(std::move(current)),
     end_(end)
   {
-    if (base() != exposition_only_end())
+    if (current_ != exposition_only_end())
       exposition_only_read();
   }
 
@@ -341,7 +341,7 @@ private:
   : current_(std::move(current)),
     end_(end)
   {
-    if (base() != exposition_only_end())
+    if (current_ != exposition_only_end())
       exposition_only_read();
     else if constexpr (!std::ranges::forward_range<exposition_only_Base>) {
       buf_index_ = -1;
@@ -350,11 +350,15 @@ private:
 
 public:
 
-  constexpr const std::ranges::iterator_t<exposition_only_Base>& base() const& noexcept {
+  constexpr const std::ranges::iterator_t<exposition_only_Base>& base() const& noexcept
+    requires std::ranges::forward_range<exposition_only_Base>
+  {
     return current_;
   }
 
-  constexpr std::ranges::iterator_t<exposition_only_Base> base() && {
+  constexpr std::ranges::iterator_t<exposition_only_Base> base() &&
+    requires std::ranges::forward_range<exposition_only_Base>
+  {
     return std::move(current_);
   }
 

--- a/papers/P2728.md
+++ b/papers/P2728.md
@@ -709,14 +709,14 @@ private:
   constexpr @*iterator*@(iterator_t<@*Base*@> begin, iterator_t<@*Base*@> current, sentinel_t<@*Base*@> end) // @*exposition only*@
     requires bidirectional_range<@*Base*@>
       : begin_(std::move(begin)), current_(std::move(current)), end_(end) {
-    if (base() != @*end*@())
+    if (current_ != @*end*@())
       @*read*@();
   }
 
   constexpr @*iterator*@(iterator_t<@*Base*@> current, sentinel_t<@*Base*@> end) // @*exposition only*@
     requires (!bidirectional_range<@*Base*@>)
       : current_(std::move(current)), end_(end) {
-    if (base() != @*end*@())
+    if (current_ != @*end*@())
       @*read*@();
     else if constexpr (!forward_range<@*Base*@>) {
       buf_index_ = -1;
@@ -724,9 +724,13 @@ private:
   }
 
 public:
-  constexpr const iterator_t<@*Base*@>& base() const& noexcept { return current_; }
+  constexpr const iterator_t<@*Base*@>& base() const& noexcept
+    requires forward_range<@*Base*@>
+  { return current_; }
 
-  constexpr iterator_t<@*Base*@> base() && { return std::move(current_); }
+  constexpr iterator_t<@*Base*@> base() &&
+    requires forward_range<@*Base*@>
+  { return std::move(current_); }
 
   constexpr value_type operator*() const;
 
@@ -824,14 +828,11 @@ encoding, into an internal code unit buffer `buf_`.
 
 ::: note
 
-`to_utf_view::@*iterator*@` maintains invariants on `base()` which
-differ depending on whether it's an input iterator. In both cases, if `*this`
-is at the end of the range being adapted, then `base()` == `@*end*@()`. But if
-it's not at the end of the adapted range, and it's an input iterator, then the
-position of `base()` is always at the end of the input subsequence
-corresponding to the current code point. On the other hand, for forward and
-bidirectional iterators, the position of `base()` is always at the beginning
-of the input subsequence corresponding to the current code point.
+`to_utf_view::@*iterator*@::base()` is only provided when the base range
+models `forward_range`. If `*this` is at the end of the range being adapted,
+then `base()` == `@*end*@()`. Otherwise, the position of `base()` is always
+at the beginning of the input subsequence corresponding to the current code
+point.
 
 :::
 
@@ -906,13 +907,13 @@ constexpr void @*read*@(); // @*exposition only*@
 
 _Effects_:
 
-Decodes the input subsequence starting at position `base()` into a code point
+Decodes the input subsequence starting at position `current_` into a code point
 `c`, using the UTF encoding corresponding to `@*from-type*@`, and setting `c`
 to U+FFFD if the input subsequence is ill-formed. It sets `to_increment_` to
 the number of code units read while decoding `c`. encodes `c` into `buf_` in
 the UTF encoding corresponding to `ToType`, and sets `buf_index_` to `0`. If
-`forward_iterator<I>` is `true`, `base()` is set to the position it had before
-`read` was called.
+`forward_range<@*Base*@>` is modeled, `current_` is set to the position it had
+before `@*read*@` was called.
 
 ```cpp
 constexpr void @*read-reverse*@(); // @*exposition only*@
@@ -920,7 +921,7 @@ constexpr void @*read-reverse*@(); // @*exposition only*@
 
 _Effects_:
 
-Decodes the input subsequence ending at position `base()` into a code point
+Decodes the input subsequence ending at position `current_` into a code point
 `c`, using the UTF encoding corresponding to `@*from-type*@`, and setting `c`
 to U+FFFD if the input subsequence is ill-formed. It sets `to_increment_` to
 the number of code units read while decoding `c`; encodes `c` into `buf_` in
@@ -1106,6 +1107,8 @@ gives back the original underlying view if it detects that it's reversing anothe
 
 ## Changes since R12
 
+- Remove `base()` from the transcoding iterator when the base range is an input
+  range and not a forward range.
 - Add `views::as_char` and `views::as_wchar_t`; it's also useful to get
   UTF-encoded strings from `charN_t` types back into `char`/`wchar_t` as well
   as having the reverse direction.

--- a/tests/beman/utf_view/to_utf_view.test.cpp
+++ b/tests/beman/utf_view/to_utf_view.test.cpp
@@ -615,11 +615,7 @@ CONSTEXPR_UNLESS_MSVC bool wrapped_view_mid_code_point_test_impl() {
     //   return false;
     // }
     if (base_testing == base_test::iterator_mid_code_point) {
-      if constexpr (!std::forward_iterator<TestIterator<char32_t>>) {
-        if (std::move(u8_begin).base() != ++make_u16_subrange().value().begin()) {
-          return false;
-        }
-      } else {
+      if constexpr (std::forward_iterator<TestIterator<char32_t>>) {
         if (std::move(u8_begin).base() != make_u16_subrange().value().begin()) {
           return false;
         }
@@ -643,14 +639,12 @@ CONSTEXPR_UNLESS_MSVC bool wrapped_view_mid_code_point_test_impl() {
     //   return false;
     // }
     if (base_testing == base_test::iterator_full_code_point) {
-      auto expected_base{make_u16_subrange().value().begin()};
-      if constexpr (!std::forward_iterator<TestIterator<char32_t>>) {
-        std::ranges::advance(expected_base, 3);
-      } else {
+      if constexpr (std::forward_iterator<TestIterator<char32_t>>) {
+        auto expected_base{make_u16_subrange().value().begin()};
         std::ranges::advance(expected_base, 1);
-      }
-      if (std::move(u8_begin).base() != expected_base) {
-        return false;
+        if (std::move(u8_begin).base() != expected_base) {
+          return false;
+        }
       }
       return true;
     }


### PR DESCRIPTION
The transcoding iterator's base() member is not meaningful for input ranges since the underlying iterator has already been consumed past the current code point. Constrain base() with forward_range so it is not provided at all when the base range is input-only.

<!--
Please take note of the following when contributing:
- Our code of conduct: https://github.com/bemanproject/beman/blob/main/docs/code_of_conduct.md
- The Beman Standard: https://github.com/bemanproject/beman/blob/main/docs/beman_standard.md
-->
