### PR TITLE
Fix [range.adaptors] subclause numbers: 24.7 -> 25.7

### DIFF
--- a/papers/P2728.md
+++ b/papers/P2728.md
@@ -457,9 +457,9 @@ Add the following to [range.utility.helpers]{.sref}:
 
 Add the following subclause to [range.adaptors]{.sref}:
 
-### 24.7.? Transcoding views [range.transcoding] {-}
+### 25.7.? Transcoding views [range.transcoding] {-}
 
-#### 24.7.?.1 Overview [range.transcoding.overview] {-}
+#### 25.7.?.1 Overview [range.transcoding.overview] {-}
 
 `to_utf_view` produces a view of the UTF code units transcoded from the
 elements of a `@*utf-range*@`. It transcodes from UTF-N to UTF-M, where N and
@@ -505,7 +505,7 @@ expression-equivalent to:
 
 - Otherwise, `to_utf_view(E, cw<Error>, to_utf_tag<Char>)`.
 
-#### 24.7.?.2 Enumeration `utf_transcoding_error` [range.transcoding.error.transcoding] {-}
+#### 25.7.?.2 Enumeration `utf_transcoding_error` [range.transcoding.error.transcoding] {-}
 
 ```c++
 enum class utf_transcoding_error {
@@ -520,7 +520,7 @@ enum class utf_transcoding_error {
 };
 ```
 
-#### 24.7.?.3 Enumeration `to_utf_view_error_kind` [range.transcoding.error.kind] {-}
+#### 25.7.?.3 Enumeration `to_utf_view_error_kind` [range.transcoding.error.kind] {-}
 
 ```c++
 enum class to_utf_view_error_kind : bool {
@@ -529,7 +529,7 @@ enum class to_utf_view_error_kind : bool {
 };
 ```
 
-#### 24.7.?.4 UTF Tags [range.transcoding.tags] {-}
+#### 25.7.?.4 UTF Tags [range.transcoding.tags] {-}
 
 ```c++
 template<@*code-unit*@ ToType>
@@ -553,7 +553,7 @@ using to_utf32_tag_t = to_utf_tag_t<char32_t>;
 constexpr to_utf32_tag_t to_utf32_tag{};
 ```
 
-#### 24.7.?.5 Class template `to_utf_view` [range.transcoding.view] {-}
+#### 25.7.?.5 Class template `to_utf_view` [range.transcoding.view] {-}
 
 ```c++
 template<input_range V, to_utf_view_error_kind E, @*code-unit*@ ToType>
@@ -665,7 +665,7 @@ its underlying range is empty.
 
 :::
 
-#### 24.7.?.6 Class `to_utf_view::@*iterator*@` [range.transcoding.iterator] {-}
+#### 25.7.?.6 Class `to_utf_view::@*iterator*@` [range.transcoding.iterator] {-}
 
 ```c++
 template<input_range V, to_utf_view_error_kind E, @*code-unit*@ ToType>
@@ -929,7 +929,7 @@ the UTF encoding corresponding to `ToType`; and sets `buf_index_` to
 `buf_.size() - 1`, or to `0` if this is an `or_error` view and we read an
 invalid subsequence.
 
-#### 24.7.?.7 Class `to_utf_view::@*sentinel*@` [range.transcoding.sentinel] {-}
+#### 25.7.?.7 Class `to_utf_view::@*sentinel*@` [range.transcoding.sentinel] {-}
 
 ```c++
 template<input_range V, to_utf_view_error_kind E, @*code-unit*@ ToType>
@@ -966,7 +966,7 @@ public:
 
 Add the following subclause to [range.adaptors]{.sref}:
 
-### 24.7.? Code unit adaptors [range.codeunitadaptor] {-}
+### 25.7.? Code unit adaptors [range.codeunitadaptor] {-}
 
 ```cpp
 template<class T>
@@ -1112,6 +1112,8 @@ gives back the original underlying view if it detects that it's reversing anothe
 - Add `views::as_char` and `views::as_wchar_t`; it's also useful to get
   UTF-encoded strings from `charN_t` types back into `char`/`wchar_t` as well
   as having the reverse direction.
+- Fix subclause numbers in wording sections to use 25.7 consistently, matching
+  the current working paper's numbering for [range.adaptors].
 
 ## Changes since R11
 


### PR DESCRIPTION
The wording sections referenced subclause 24.7, but [range.adaptors] is 25.7 in the current working paper. Fix all occurrences to use the correct number, addressing SG16 editor's note.

<!--
Please take note of the following when contributing:
- Our code of conduct: https://github.com/bemanproject/beman/blob/main/docs/code_of_conduct.md
- The Beman Standard: https://github.com/bemanproject/beman/blob/main/docs/beman_standard.md
-->
