### PR TITLE
Add <ranges> header synopsis wording

### DIFF
--- a/papers/P2728.md
+++ b/papers/P2728.md
@@ -453,6 +453,59 @@ Add the following to [range.utility.helpers]{.sref}:
       same_as<remove_cv_t<T>, char8_t> || same_as<remove_cv_t<T>, char16_t> || same_as<remove_cv_t<T>, char32_t>;
 ```
 
+## Header `<ranges>` synopsis
+
+Add the following to [ranges.syn]{.sref}, after the `as_input_view` entries:
+
+```c++
+  // [range.transcoding], transcoding views
+  enum class utf_transcoding_error;
+  enum class to_utf_view_error_kind : bool;
+
+  template<@*code-unit*@ ToType>
+  struct to_utf_tag_t;
+
+  template<@*code-unit*@ ToType>
+  constexpr to_utf_tag_t<ToType> to_utf_tag{};
+
+  using to_utf8_tag_t = to_utf_tag_t<char8_t>;
+  constexpr to_utf8_tag_t to_utf8_tag{};
+
+  using to_utf16_tag_t = to_utf_tag_t<char16_t>;
+  constexpr to_utf16_tag_t to_utf16_tag{};
+
+  using to_utf32_tag_t = to_utf_tag_t<char32_t>;
+  constexpr to_utf32_tag_t to_utf32_tag{};
+
+  template<input_range V, to_utf_view_error_kind E, @*code-unit*@ ToType>
+    requires view<V> && @*code-unit*@<range_value_t<V>>
+  class to_utf_view;
+
+  template<class V, to_utf_view_error_kind E, class ToType>
+    constexpr bool enable_borrowed_range<to_utf_view<V, E, ToType>> =
+      enable_borrowed_range<V>;
+
+  namespace views {
+    template<@*code-unit*@ ToType> inline constexpr @*unspecified*@ to_utf = @*unspecified*@;
+    template<@*code-unit*@ ToType> inline constexpr @*unspecified*@ to_utf_or_error = @*unspecified*@;
+    inline constexpr @*unspecified*@ to_utf8 = @*unspecified*@;
+    inline constexpr @*unspecified*@ to_utf8_or_error = @*unspecified*@;
+    inline constexpr @*unspecified*@ to_utf16 = @*unspecified*@;
+    inline constexpr @*unspecified*@ to_utf16_or_error = @*unspecified*@;
+    inline constexpr @*unspecified*@ to_utf32 = @*unspecified*@;
+    inline constexpr @*unspecified*@ to_utf32_or_error = @*unspecified*@;
+  }
+
+  // [range.codeunitadaptor], code unit adaptors
+  namespace views {
+    inline constexpr @*unspecified*@ as_char = @*unspecified*@;
+    inline constexpr @*unspecified*@ as_wchar_t = @*unspecified*@;
+    inline constexpr @*unspecified*@ as_char8_t = @*unspecified*@;
+    inline constexpr @*unspecified*@ as_char16_t = @*unspecified*@;
+    inline constexpr @*unspecified*@ as_char32_t = @*unspecified*@;
+  }
+```
+
 ## Transcoding views
 
 Add the following subclause to [range.adaptors]{.sref}:
@@ -1114,6 +1167,7 @@ gives back the original underlying view if it detects that it's reversing anothe
   as having the reverse direction.
 - Fix subclause numbers in wording sections to use 25.7 consistently, matching
   the current working paper's numbering for [range.adaptors].
+- Add wording for changes to the `<ranges>` header synopsis in [ranges.syn].
 
 ## Changes since R11
 


### PR DESCRIPTION
The wording was missing changes to [ranges.syn] for the new types and views introduced by the paper. Add forward declarations for utf_transcoding_error, to_utf_view_error_kind, to_utf_tag_t, to_utf_view, and all the views::to_utf*/as_char* range adaptor objects.

<!--
Please take note of the following when contributing:
- Our code of conduct: https://github.com/bemanproject/beman/blob/main/docs/code_of_conduct.md
- The Beman Standard: https://github.com/bemanproject/beman/blob/main/docs/beman_standard.md
-->
