### PR TITLE
Expand "CTP" abbreviation in transcoding overview

### DIFF
--- a/papers/P2728.md
+++ b/papers/P2728.md
@@ -520,7 +520,7 @@ M are each one of 8, 16, or 32. N may equal M. `to_utf_view`'s
 `ToType` template parameter is based on a mapping between character types and
 UTF encodings, which is that that `char8_t` corresponds to UTF-8, `char16_t`
 corresponds to UTF-16, and `char32_t` corresponds to UTF-32. If its
-`to_utf_view_error_kind` CTP is `expected`, it produces a view of
+`to_utf_view_error_kind` constant template parameter is `expected`, it produces a view of
 `expected<charN_t, utf_transcoding_error>` where invalid input subsequences
 result in errors.
 
@@ -1168,6 +1168,7 @@ gives back the original underlying view if it detects that it's reversing anothe
 - Fix subclause numbers in wording sections to use 25.7 consistently, matching
   the current working paper's numbering for [range.adaptors].
 - Add wording for changes to the `<ranges>` header synopsis in [ranges.syn].
+- Expand "CTP" abbreviation to "constant template parameter" in [range.transcoding.overview].
 
 ## Changes since R11
 


### PR DESCRIPTION
Replace the abbreviation "CTP" with "constant template parameter" in [range.transcoding.overview] for clarity.

<!--
Please take note of the following when contributing:
- Our code of conduct: https://github.com/bemanproject/beman/blob/main/docs/code_of_conduct.md
- The Beman Standard: https://github.com/bemanproject/beman/blob/main/docs/beman_standard.md
-->
