### PR TITLE
Add missing "Otherwise" before expression-equivalent clauses

### DIFF
--- a/papers/P2728.md
+++ b/papers/P2728.md
@@ -538,7 +538,7 @@ let `Char` be its corresponding character type, and let `Error` be its
 corresponding `to_utf_view_error_kind`. Let `E` be an expression and let `T`
 be `remove_cvref_t<decltype((E))>`. If `decltype((E))` does not model
 `@*utf-range*@`, or if `T` is an array of `char8_t`, `char16_t`, or
-`char32_t`, `to_utfN(E)` is ill-formed. The expression `to_utfN(E)` is
+`char32_t`, `to_utfN(E)` is ill-formed. Otherwise, the expression `to_utfN(E)` is
 expression-equivalent to:
 
 - If `E` is a specialization of `empty_view` ([range.empty.view]):
@@ -1035,7 +1035,7 @@ The names `as_char`, `as_wchar_t`, `as_char8_t`, `as_char16_t`, and
 type for `as_charT`, let `E` be an expression and let `T` be
 `remove_cvref_t<decltype((E))>`. If `ranges::range_reference_t<T>` does not
 model `convertible_to<Char>`, or if `T` is an array, `as_charT(E)` is
-ill-formed. The expression `as_charT(E)` is expression-equivalent to:
+ill-formed. Otherwise, the expression `as_charT(E)` is expression-equivalent to:
 
 - If `T` is a specialization of `empty_view` ([range.empty.view]), then
   `empty_view<Char>{}`.
@@ -1169,6 +1169,8 @@ gives back the original underlying view if it detects that it's reversing anothe
   the current working paper's numbering for [range.adaptors].
 - Add wording for changes to the `<ranges>` header synopsis in [ranges.syn].
 - Expand "CTP" abbreviation to "constant template parameter" in [range.transcoding.overview].
+- Add missing "Otherwise" before expression-equivalent clauses in
+  [range.transcoding.overview] and [range.codeunitadaptor].
 
 ## Changes since R11
 


### PR DESCRIPTION
After the ill-formed case, the following expression-equivalent clause needs "Otherwise" per standard wording conventions. Applied to both [range.transcoding.overview] and [range.codeunitadaptor].

<!--
Please take note of the following when contributing:
- Our code of conduct: https://github.com/bemanproject/beman/blob/main/docs/code_of_conduct.md
- The Beman Standard: https://github.com/bemanproject/beman/blob/main/docs/beman_standard.md
-->
