### PR TITLE
Give utf_transcoding_error and to_utf_view_error_kind unspecified underlying types

### DIFF
--- a/papers/P2728.md
+++ b/papers/P2728.md
@@ -459,8 +459,8 @@ Add the following to [ranges.syn]{.sref}, after the `as_input_view` entries:
 
 ```c++
   // [range.transcoding], transcoding views
-  enum class utf_transcoding_error;
-  enum class to_utf_view_error_kind : bool;
+  enum class utf_transcoding_error : @*unspecified*@;
+  enum class to_utf_view_error_kind : @*unspecified*@;
 
   template<@*code-unit*@ ToType>
   struct to_utf_tag_t;
@@ -561,7 +561,7 @@ expression-equivalent to:
 #### 25.7.?.2 Enumeration `utf_transcoding_error` [range.transcoding.error.transcoding] {-}
 
 ```c++
-enum class utf_transcoding_error {
+enum class utf_transcoding_error : @*unspecified*@ {
   truncated_utf8_sequence,
   unpaired_high_surrogate,
   unpaired_low_surrogate,
@@ -576,7 +576,7 @@ enum class utf_transcoding_error {
 #### 25.7.?.3 Enumeration `to_utf_view_error_kind` [range.transcoding.error.kind] {-}
 
 ```c++
-enum class to_utf_view_error_kind : bool {
+enum class to_utf_view_error_kind : @*unspecified*@ {
   replacement,
   expected
 };
@@ -1160,6 +1160,11 @@ gives back the original underlying view if it detects that it's reversing anothe
 
 ## Changes since R12
 
+- Give `utf_transcoding_error` and `to_utf_view_error_kind` unspecified
+  underlying types, following the precedent of `memory_order`, `launch`, and
+  `assertion_kind`. Fixing the underlying type (to `int` or `bool`) is an
+  unnecessary constraint; an unspecified underlying type gives implementations
+  freedom to choose a type suited to their layout and ABI needs.
 - Remove `base()` from the transcoding iterator when the base range is an input
   range and not a forward range.
 - Add `views::as_char` and `views::as_wchar_t`; it's also useful to get


### PR DESCRIPTION
Following the precedent of memory_order, launch, and assertion_kind. Fixing the underlying type (to int or bool) is an unnecessary constraint; an unspecified underlying type gives implementations freedom to choose a type suited to their layout and ABI needs.

<!--
Please take note of the following when contributing:
- Our code of conduct: https://github.com/bemanproject/beman/blob/main/docs/code_of_conduct.md
- The Beman Standard: https://github.com/bemanproject/beman/blob/main/docs/beman_standard.md
-->
