### PR TITLE
Add fixed-size buffer transcoding example

### DIFF
--- a/examples/readme_examples.cpp
+++ b/examples/readme_examples.cpp
@@ -254,6 +254,34 @@ std::u8string parse_message_subset(
 }
 #endif
 
+#if __cpp_lib_ranges_chunk_by >= 202202L
+template <typename T>
+constexpr bool is_continuation(T c) {
+  if constexpr (std::is_same_v<decltype(c), char8_t>) {
+    return (c & 0xC0) == 0x80;
+  } else if constexpr (std::is_same_v<decltype(c), char16_t>) {
+    return c >= 0xDC00 && c <= 0xDFFF;
+  } else {
+    return false;
+  }
+}
+
+template <typename FromType, typename ToType, std::size_t N>
+constexpr detail::fake_inplace_vector<ToType, N> transcode_trucating_correctly(
+    std::basic_string_view<FromType> input) {
+  detail::fake_inplace_vector<ToType, N> output;
+  for (auto code_point_view : input
+       | to_utf<ToType>
+       | std::views::chunk_by([](auto, auto b) { return is_continuation(b); })) {
+    if (static_cast<std::size_t>(std::ranges::distance(code_point_view))
+        > output.max_size() - output.size())
+      break;
+    std::ranges::copy(code_point_view, std::back_insert_iterator{output});
+  }
+  return output;
+}
+#endif
+
 bool readme_examples() {
   using namespace std::string_view_literals;
 #ifndef _MSC_VER
@@ -305,6 +333,24 @@ bool readme_examples() {
     std::byte{0x34}};
   if (!std::ranges::equal(u8"\xf0\x9f\x99\x82"sv, parse_message_subset(message, 1, 4))) {
     return false;
+  }
+  {
+    auto result = transcode_trucating_correctly<char8_t, char16_t, 5>(u8"😀abc"sv);
+    if (result.size() != 5) {
+      return false;
+    }
+    auto result2 = transcode_trucating_correctly<char8_t, char16_t, 4>(u8"😀abc"sv);
+    if (result2.size() != 4) {
+      return false;
+    }
+    auto result3 = transcode_trucating_correctly<char8_t, char16_t, 2>(u8"😀abc"sv);
+    if (result3.size() != 2) {
+      return false;
+    }
+    auto result4 = transcode_trucating_correctly<char8_t, char16_t, 1>(u8"😀abc"sv);
+    if (result4.size() != 0) {
+      return false;
+    }
   }
 #endif
 #endif

--- a/include/beman/utf_view/detail/fake_inplace_vector.hpp
+++ b/include/beman/utf_view/detail/fake_inplace_vector.hpp
@@ -28,6 +28,8 @@ namespace beman::utf_view::detail {
 template <typename T, std::size_t N>
 class fake_inplace_vector {
 public:
+  using value_type = T;
+
   constexpr fake_inplace_vector() = default;
   constexpr fake_inplace_vector(std::initializer_list<T> init)
   : size_{init.size()}
@@ -38,6 +40,9 @@ public:
   constexpr std::size_t size() const {
     return size_;
   }
+  static constexpr std::size_t max_size() {
+    return N;
+  }
   constexpr void clear() {
     size_ = 0;
   }
@@ -47,10 +52,10 @@ public:
   constexpr T operator[](std::size_t n) const {
     return storage_[n];
   }
-  T* begin() {
+  constexpr T* begin() {
     return &storage_[0];
   }
-  T* end() {
+  constexpr T* end() {
     return &storage_[size_];
   }
 

--- a/papers/P2728.md
+++ b/papers/P2728.md
@@ -422,6 +422,36 @@ std::u8string parse_message_subset(
 
 Note that this depends on P4030R0 "Endian Views" for `std::views::from_big_endian`.
 
+## Transcoding into a buffer of a fixed number of code units without truncating code points
+
+```
+template <typename T>
+constexpr bool is_continuation(T c) {
+  if constexpr (std::is_same_v<decltype(c), char8_t>) {
+    return (c & 0xC0) == 0x80;
+  } else if constexpr (std::is_same_v<decltype(c), char16_t>) {
+    return c >= 0xDC00 && c <= 0xDFFF;
+  } else {
+    return false;
+  }
+}
+
+template <typename FromType, typename ToType, std::size_t N>
+constexpr std::inplace_vector<ToType, N> transcode_trucating_correctly(
+    std::basic_string_view<FromType> input) {
+  std::inplace_vector<ToType, N> output;
+  for (auto code_point_view : input
+       | std::views::to_utf<ToType>
+       | std::views::chunk_by([](auto, auto b) { return is_continuation(b); })) {
+    if (std::ranges::distance(code_point_view)
+        > static_cast<std::ptrdiff_t>(output.max_size() - output.size()))
+      break;
+    std::ranges::copy(code_point_view, std::back_insert_iterator{output});
+  }
+  return output;
+}
+```
+
 # Dependencies
 
 The code unit views depend on [@P3117R1] "Extending Conditionally Borrowed".
@@ -1160,6 +1190,8 @@ gives back the original underlying view if it detects that it's reversing anothe
 
 ## Changes since R12
 
+- Add example: transcoding into a fixed-size buffer without truncating
+  code points.
 - Give `utf_transcoding_error` and `to_utf_view_error_kind` unspecified
   underlying types, following the precedent of `memory_order`, `launch`, and
   `assertion_kind`. Fixing the underlying type (to `int` or `bool`) is an


### PR DESCRIPTION
Demonstrates transcoding into a fixed-capacity buffer (inplace_vector) without truncating multi-code-unit sequences, using chunk_by to group code units by code point. Also adds value_type, max_size(), and constexpr begin()/end() to fake_inplace_vector.

<!--
Please take note of the following when contributing:
- Our code of conduct: https://github.com/bemanproject/beman/blob/main/docs/code_of_conduct.md
- The Beman Standard: https://github.com/bemanproject/beman/blob/main/docs/beman_standard.md
-->
