### PR TITLE
Add cuneiform substring replacement example

### DIFF
--- a/examples/readme_examples.cpp
+++ b/examples/readme_examples.cpp
@@ -353,6 +353,19 @@ bool readme_examples() {
     }
   }
 #endif
+  {
+    std::u16string zamin = u"𒀭𒎏𒄈𒋢𒍠𒊩";
+    auto view = zamin | to_utf32;
+    auto begin = view.begin();
+    ++begin;
+    auto ningirsuBegin = begin.base();
+    std::ranges::advance(begin, 3);
+    auto ningirsuEnd = begin.base();
+    zamin.replace(ningirsuBegin, ningirsuEnd, u"𒊺𒉀");
+    if (!std::ranges::equal(zamin, u"𒀭𒊺𒉀𒍠𒊩"sv)) {
+      return false;
+    }
+  }
 #endif
   return true;
 }

--- a/papers/P2728.md
+++ b/papers/P2728.md
@@ -424,7 +424,7 @@ Note that this depends on P4030R0 "Endian Views" for `std::views::from_big_endia
 
 ## Transcoding into a buffer of a fixed number of code units without truncating code points
 
-```
+```cpp
 template <typename T>
 constexpr bool is_continuation(T c) {
   if constexpr (std::is_same_v<decltype(c), char8_t>) {
@@ -450,6 +450,22 @@ constexpr std::inplace_vector<ToType, N> transcode_trucating_correctly(
   }
   return output;
 }
+```
+
+## Performing code unit substitutions on cuneiform strings:
+
+```cpp
+// Adapted from an ICU unit test:
+// https://github.com/unicode-org/icu/blob/649262a75ecddb15a0e58d71f637a8a32eaabd43/icu4c/source/test/intltest/utfiteratortest.cpp#L1205-L1228
+std::u16string zamin = u"𒀭𒎏𒄈𒋢𒍠𒊩";
+auto it = zamin | std::views::to_utf32;
+auto begin = it.begin();
+++begin;
+auto ningirsuBegin = begin.base();
+std::advance(begin, 3); // was 2 + implicit end()
+auto ningirsuEnd = begin.base();
+zamin.replace(ningirsuBegin, ningirsuEnd, u"𒊺𒉀");
+assert(std::ranges::equal(zamin, u"𒀭𒊺𒉀𒍠𒊩"sv));
 ```
 
 # Dependencies
@@ -1192,6 +1208,8 @@ gives back the original underlying view if it detects that it's reversing anothe
 
 - Add example: transcoding into a fixed-size buffer without truncating
   code points.
+- Add example: using `to_utf32` and `base()` for code point-aware
+  substring replacement on cuneiform text, adapted from an ICU unit test.
 - Give `utf_transcoding_error` and `to_utf_view_error_kind` unspecified
   underlying types, following the precedent of `memory_order`, `launch`, and
   `assertion_kind`. Fixing the underlying type (to `int` or `bool`) is an


### PR DESCRIPTION
Demonstrates using to_utf32 iterators and base() to navigate a UTF-16 cuneiform string by code point, then replacing a substring at code point boundaries. Adapted from an ICU unit test.

<!--
Please take note of the following when contributing:
- Our code of conduct: https://github.com/bemanproject/beman/blob/main/docs/code_of_conduct.md
- The Beman Standard: https://github.com/bemanproject/beman/blob/main/docs/beman_standard.md
-->
