### PR TITLE
Endian views: preserve contiguity in the no-op cases

### DIFF
--- a/include/beman/utf_view/endian_view.hpp
+++ b/include/beman/utf_view/endian_view.hpp
@@ -33,23 +33,9 @@ namespace detail {
 
 /* PAPER */
 
-struct exposition_only_byteswap_if_native_is_big_endian {
+struct exposition_only_byteswap {
   constexpr auto operator()(auto x) const noexcept {
-    if constexpr (std::endian::native == std::endian::big) {
-      return std::byteswap(x);
-    } else {
-      return x;
-    }
-  }
-};
-
-struct exposition_only_byteswap_if_native_is_little_endian { // @*exposition only*@/
-  constexpr auto operator()(auto x) const noexcept {
-    if constexpr (std::endian::native == std::endian::little) {
-      return std::byteswap(x);
-    } else {
-      return x;
-    }
+    return std::byteswap(x);
   }
 };
 
@@ -59,9 +45,9 @@ struct exposition_only_byteswap_if_native_is_little_endian { // @*exposition onl
 
 namespace detail {
 
-  template <bool byteswap_if_native_is_big>
+  template <std::endian endianness>
   struct from_to_endian_impl
-      : std::ranges::range_adaptor_closure<from_to_endian_impl<byteswap_if_native_is_big>> {
+      : std::ranges::range_adaptor_closure<from_to_endian_impl<endianness>> {
     template <std::ranges::range R>
       requires std::integral<std::ranges::range_value_t<R>>
     constexpr auto operator()(R&& r) const {
@@ -69,12 +55,11 @@ namespace detail {
       if constexpr (detail::is_empty_view<T>) {
         return std::ranges::empty_view<std::ranges::range_value_t<T>>{};
       } else {
-        if constexpr (byteswap_if_native_is_big) {
-          return beman::transform_view::transform_view(
-              std::forward<R>(r), exposition_only_byteswap_if_native_is_big_endian{});
+        if constexpr (std::endian::native == endianness) {
+          return std::views::all(std::forward<R>(r));
         } else {
           return beman::transform_view::transform_view(
-              std::forward<R>(r), exposition_only_byteswap_if_native_is_little_endian{});
+              std::forward<R>(r), exposition_only_byteswap{});
         }
       }
     }
@@ -82,21 +67,18 @@ namespace detail {
 
 } // namespace detail
 
-inline constexpr detail::from_to_endian_impl<true> from_little_endian;
+inline constexpr detail::from_to_endian_impl<std::endian::little> from_little_endian;
 
-inline constexpr detail::from_to_endian_impl<false> from_big_endian;
+inline constexpr detail::from_to_endian_impl<std::endian::big> from_big_endian;
 
-inline constexpr detail::from_to_endian_impl<true> to_little_endian;
+inline constexpr detail::from_to_endian_impl<std::endian::little> to_little_endian;
 
-inline constexpr detail::from_to_endian_impl<false> to_big_endian;
+inline constexpr detail::from_to_endian_impl<std::endian::big> to_big_endian;
 
-/* PAPER:   inline constexpr @*unspecified*@ from_little_endian;  */
-/* PAPER:                                                         */
-/* PAPER:   inline constexpr @*unspecified*@ from_big_endian;     */
-/* PAPER:                                                         */
-/* PAPER:   inline constexpr @*unspecified*@ to_little_endian;    */
-/* PAPER:                                                         */
-/* PAPER:   inline constexpr @*unspecified*@ to_big_endian;       */
+/* PAPER:   inline constexpr @*unspecified*@ from_little_endian = @*unspecified*@;  */
+/* PAPER:   inline constexpr @*unspecified*@ from_big_endian = @*unspecified*@;     */
+/* PAPER:   inline constexpr @*unspecified*@ to_little_endian = @*unspecified*@;    */
+/* PAPER:   inline constexpr @*unspecified*@ to_big_endian = @*unspecified*@;       */
 
 /* PAPER: } */
 

--- a/papers/P4030.md
+++ b/papers/P4030.md
@@ -1,7 +1,7 @@
 ---
 title: "Endian Views"
-document: P4030R0
-date: 2026-02-22
+document: P4030R1
+date: 2026-06-05
 audience:
   - SG-9 Ranges
   - SG-16 Unicode
@@ -17,7 +17,7 @@ monofont: "DejaVu Sans Mono"
 # Motivation
 
 The main reason for adding these views is to assist users of the UTF transcoding range
-adaptors (see [@P2728R7]). That paper introduces the adaptors `to_utf8`, `to_utf16`, and
+adaptors (see [@P2728R12]). That paper introduces the adaptors `to_utf8`, `to_utf16`, and
 `to_utf32`, which take as input ranges of `char8_t`, `char16_t`, and `char32_t`. The input
 and output of these views use native endianness. But users often need to convert to and
 from UTF encodings with specific endianness: UTF-16LE, UTF-16BE, UTF-32LE, and UTF-32BE.
@@ -150,30 +150,30 @@ This paper depends on [@P3117R1] "Extending Conditionally Borrowed".
 
 # Wording
 
-Add the following subclause to [range.adaptors]{.sref}:
+## Header `<ranges>` synopsis
 
-## 24.7.? Endianness adaptors [range.endianadaptor] {-}
+Add the following to [ranges.syn]{.sref}, after the `to_input_view` entries:
 
-```cpp
-struct @*byteswap-if-native-is-big-endian*@ { // @*exposition only*@/
-  constexpr auto operator()(auto x) const noexcept {
-    if constexpr (endian::native == endian::big) {
-      return std::byteswap(x);
-    } else {
-      return x;
-    }
+```c++
+  // [range.endianadaptor], endianness adaptors
+  namespace views {
+    inline constexpr @*unspecified*@ from_little_endian = @*unspecified*@;
+    inline constexpr @*unspecified*@ from_big_endian = @*unspecified*@;
+    inline constexpr @*unspecified*@ to_little_endian = @*unspecified*@;
+    inline constexpr @*unspecified*@ to_big_endian = @*unspecified*@;
   }
-};
 ```
 
+## Endianness adaptors
+
+Add the following subclause to [range.adaptors]{.sref}:
+
+### 24.7.? Endianness adaptors [range.endianadaptor] {-}
+
 ```cpp
-struct @*byteswap-if-native-is-little-endian*@ { // @*exposition only*@/
+struct @*byteswap*@ { // @*exposition only*@/
   constexpr auto operator()(auto x) const noexcept {
-    if constexpr (endian::native == endian::little) {
-      return std::byteswap(x);
-    } else {
-      return x;
-    }
+    return std::byteswap(x);
   }
 };
 ```
@@ -189,8 +189,8 @@ ill-formed. The expression `from_little_endian(E)` is expression-equivalent to:
 
 - If `T` is a specialization of `empty_view` ([range.empty.view]), then
   `empty_view<range_value_t<T>>{}`.
-- Otherwise, `ranges::transform_view(std::views::all(E),
-  @*byteswap-if-native-is-big-endian*@{})`.
+- Otherwise, if `std::endian::native == std::endian::little`, `std::views::all(E)`.
+- Otherwise, `ranges::transform_view(std::views::all(E), @*byteswap*@{})`.
 
 The name `from_big_endian` denotes a range adaptor object ([range.adaptor.object]). Let
 `E` be an expression and let `T` be `remove_cvref_t<decltype((E))>`. If
@@ -199,8 +199,8 @@ ill-formed. The expression `from_big_endian(E)` is expression-equivalent to:
 
 - If `T` is a specialization of `empty_view` ([range.empty.view]), then
   `empty_view<range_value_t<T>>{}`.
-- Otherwise, `ranges::transform_view(std::views::all(E),
-  @*byteswap-if-native-is-little-endian*@{})`.
+- Otherwise, if `std::endian::native == std::endian::big`, `std::views::all(E)`.
+- Otherwise, `ranges::transform_view(std::views::all(E), @*byteswap*@{})`.
 
 The name `to_little_endian` denotes a range adaptor object ([range.adaptor.object]). Let
 `E` be an expression and let `T` be `remove_cvref_t<decltype((E))>`. If
@@ -209,8 +209,8 @@ ill-formed. The expression `to_little_endian(E)` is expression-equivalent to:
 
 - If `T` is a specialization of `empty_view` ([range.empty.view]), then
   `empty_view<range_value_t<T>>{}`.
-- Otherwise, `ranges::transform_view(std::views::all(E),
-  @*byteswap-if-native-is-big-endian*@{})`.
+- Otherwise, if `std::endian::native == std::endian::little`, `std::views::all(E)`.
+- Otherwise, `ranges::transform_view(std::views::all(E), @*byteswap*@{})`.
 
 The name `to_big_endian` denotes a range adaptor object ([range.adaptor.object]). Let `E`
 be an expression and let `T` be `remove_cvref_t<decltype((E))>`. If
@@ -219,8 +219,8 @@ ill-formed. The expression `to_big_endian(E)` is expression-equivalent to:
 
 - If `T` is a specialization of `empty_view` ([range.empty.view]), then
   `empty_view<range_value_t<T>>{}`.
-- Otherwise, `ranges::transform_view(std::views::all(E),
-  @*byteswap-if-native-is-little-endian*@{})`.
+- Otherwise, if `std::endian::native == std::endian::big`, `std::views::all(E)`.
+- Otherwise, `ranges::transform_view(std::views::all(E), @*byteswap*@{})`.
 
 ## Feature test macro
 
@@ -238,3 +238,14 @@ adoption of this paper:
 thing. We include both names for the sake of pipeline readability; it would be harder to
 read the pipelines if we used names like `from_or_to_little_endian` or
 `byteswap_if_native_is_big_endian`.
+
+If the input and output endianness are the same, we give back `views::all` of the original
+range in order to preserve contiguity.
+
+# Changelog
+
+## Changes since R0
+
+- Preserve contiguity by ensuring that we don't give out a `transform_view` if the input
+  and output endianness are the same
+- Add `<ranges>` synopsis

--- a/tests/beman/utf_view/endian_view.test.cpp
+++ b/tests/beman/utf_view/endian_view.test.cpp
@@ -107,6 +107,20 @@ static_assert(
                   test_random_access_iterator<int>, test_random_access_iterator<int>>>()
           | from_big_endian)>>);
 
+static_assert(
+  std::endian::native == std::endian::big ||
+  std::contiguous_iterator<
+    std::ranges::iterator_t<
+        decltype(std::declval< std::ranges::subrange<int*, int*>>()
+          | from_little_endian)>>);
+
+static_assert(
+  std::endian::native == std::endian::little ||
+  std::contiguous_iterator<
+    std::ranges::iterator_t<
+        decltype(std::declval< std::ranges::subrange<int*, int*>>()
+          | from_big_endian)>>);
+
 constexpr bool smoke_test() {
   std::vector<int> foo{0x12345678};
   auto bar{foo | from_big_endian};


### PR DESCRIPTION
Also add a <ranges> synopsis.

<!--
Please take note of the following when contributing:
- Our code of conduct: https://github.com/bemanproject/beman/blob/main/docs/code_of_conduct.md
- The Beman Standard: https://github.com/bemanproject/beman/blob/main/docs/beman_standard.md
-->
