### PR TITLE
Discuss .base_code_units() returning inplace_vector for input ranges

### DIFF
--- a/papers/P2728.md
+++ b/papers/P2728.md
@@ -1265,8 +1265,8 @@ This is a run-length-encoder that prints a count of the number of consecutive ti
 seen a code point, followed by the code units making up that code point:
 
 ```cpp
-void print_runs(std::ranges::range auto input) {
-  auto utf_view = input | std::views::to_utf32;
+void print_runs(std::ranges::range auto text) {
+  auto utf_view = text | std::views::to_utf32;
   auto it = utf_view.begin();
   while (it != utf_view.end()) {
     auto units = it.base_code_units();
@@ -1302,6 +1302,170 @@ them for forward ranges.
 
 I think this footgun would show up frequently.
 
+In response, it was suggested that the above lifetime issue could be addressed by changing
+the return type of `.base_code_units()` to something like `std::inplace_vector<char8_t,
+4>`.
+
+That creates a different lifetime problem. Consider this example. The Unicode Tags block
+is intended for use in flag emojis but has been used for LLM prompt injections. Say a user
+writes the following function, which divides the stream of characters into Tags and
+non-Tags, and also imagine that they have a custom sink type that accepts iterator pairs
+rather than ranges:
+
+```cpp
+constexpr bool is_tag(char32_t c) { return (c & ~0x7F) == 0xE0000; }
+
+void partition_tags(std::ranges::range auto text, sink non_tags, sink tags) {
+  auto utf_view = text | std::views::to_utf32;
+  for (auto it = utf_view.begin(); it != utf_view.end(); ++it) {
+    (is_tag(*it) ? tags : non_tags).consume(
+      it.base_code_units().begin(), it.base_code_units().end());
+  }
+}
+```
+
+Again, this works perfectly well when `partition_tags` is passed a forward range, but then
+when it's passed an input range, because each call to `.base_code_units()` returns a
+separate temporary `std::inplace_vector`, `it.base_code_units().begin()` and
+`it.base_code_units().end()` now point to different objects, so the function invokes UB.
+
+### Survey of Range Adaptors that Downgrade to Input
+
+Some range adaptors downgrade forward ranges into input ranges: these are, to my
+understanding, `views::as_input`, `views::cache_latest`, `views::join`, and
+`views::join_with`.
+
+`views::as_input` was introduced by [@P3725R3], "Filter View Extensions for Safer Use,"
+and although it's potentially applicable to other use cases, the reason it was introduced
+was composition with `std::views::filter` in order to avoid pitfalls related to mutating
+through a filter.
+
+This is potentially relevant to transcoding, in that someone might write a filter-view
+pipeline on characters. Say a user wants to print the UTF-8 code units for all the
+non-ASCII code points in a range. That would look like this:
+
+```cpp
+void print_nonascii_code_points_and_code_units(std::ranges::range auto text) {
+  auto print_code_point{
+    [](char32_t code_point, auto code_unit_range) {
+    std::println(
+      "{:#x} = {::#x}", static_cast<std::uint32_t>(code_point),
+      code_unit_range | std::views::transform([](char8_t c) { return (std::uint8_t)c; }));
+    }};
+  auto code_points = text
+                     | std::views::filter([](char8_t c) { return c >= 0x80; })
+                     | std::views::to_utf32;
+  for (auto it = code_points.begin(); it != code_points.end(); ++it) {
+    print_code_point(*it, it.base_code_units());
+  }
+}
+```
+
+A user following the [@P3725R3] guidance might insert a `views::as_input` adaptor into the
+pipeline before `std::views::filter`, which would continue to compile and work if we
+provided `.base_code_units()` for input ranges, but which would cause
+`print_nonascii_code_points_and_code_units` to fail to compile if we didn't.
+
+But `views::as_input` isn't strictly necessary here. And we already need to teach users
+that inserting `views::as_input` before `std::views::filter` will, in rare cases, cause
+some uses of `.base()` to fail to compile. To demonstrate why this isn't a novelty,
+consider the following example:
+
+```cpp
+struct Task { int priority; };
+
+bool submit_batch(std::ranges::range auto batch);
+
+// Submit the high-priority tasks in batches; on a transient failure, hand the
+// remaining high-priority tasks to the retry queue.
+void submit_high_priority_tasks(std::vector<Task>& tasks) {
+  auto high = tasks | std::views::filter([](Task const& t) { return t.priority > 100; });
+  auto batches = high | std::views::chunk(BATCH_SIZE);
+  for (auto it = batches.begin(); it != batches.end(); ++it) {
+    if (!submit_batch(*it)) {
+      requeue(std::ranges::subrange(it.base(), high.end()));
+      return;
+    }
+  }
+}
+```
+
+This works as written, but if `views::as_input` is inserted in front of `views::filter`,
+the call to `it.base()` fails to compile because `std::ranges::chunk_view`'s iterator
+doesn't provide `.base()` for input views. But `views::as_input` is unnecessary here as
+well.
+
+Furthermore, it's worth noting that the list of plausible reasons to apply a filter_view
+on code *units* as opposed to code *points* is extremely short; ordinarily, doing so risks
+corrupting the output.
+
+Moving on to `views::cache_latest`: that one is an adaptor with a niche use case and no
+special relevance to transcoding.
+
+`views::join` is directly relevant, since it's common for users to want to reassemble a
+text string that had previously been broken up into separate parts before transcoding
+it. `views::join_with` is also potentially relevant, since users may want to transcode
+text after having used `views::join_with` to add separators to it.
+
+It's important to note that in the common case, `views::join` and `views::join_with` do
+not downgrade from forward to input. They only do so if the range of ranges it's given is
+a range of *prvalue* ranges.
+
+For example, the `views::join` adaptor in the following example does not downgrade:
+
+```cpp
+void print_errors(std::ranges::range auto packets) {
+  auto print_code_units =
+    [](std::ranges::range auto code_unit) {
+      std::println("{::#x}",
+                   code_unit
+                   | std::views::transform([](char8_t c) { return (std::uint8_t)c; }));
+    };
+  auto utf_view = packets
+                | std::views::join
+                | std::views::to_utf32_or_error;
+  for (auto it = utf_view.begin(); it != utf_view.end(); ++it) {
+    if (!(*it).has_value()) {
+      print_code_units(it.base_code_units());
+    }
+  }
+}
+```
+
+But, if the packets need to be decrypted before transcoding, and the user alters the
+pipeline like so:
+
+```diff
++ std::u8string decrypt(std::u8string_view packet) {
++   return packet
++          | std::views::transform(
++              [](char8_t c) {
++                return static_cast<char8_t>(c ^ 0x55);
++              })
++          | std::ranges::to<std::u8string>();
++ }
+
+void print_errors(std::ranges::range auto packets) {
+  auto print_code_units =
+    [](std::ranges::range auto code_unit) {
+      std::println("{::#x}",
+                   code_unit
+                   | std::views::transform([](char8_t c) { return (std::uint8_t)c; }));
+    };
+  auto utf_view = packets
++               | std::views::transform(decrypt)
+                | std::views::join
+                | std::views::to_utf32_or_error;
+  for (auto it = utf_view.begin(); it != utf_view.end(); ++it) {
+    if (!(*it).has_value()) {
+      print_code_units(it.base_code_units());
+    }
+  }
+}
+```
+
+Then it downgrades.
+
 ### Alternatives to `.base_code_units()` for Users
 
 #### Forward Ranges
@@ -1330,14 +1494,14 @@ If it's viable to copy the entire range, you can simply insert a
 `std::ranges::to<std::u8string>()` into the range pipeline.
 
 ```cpp
-void print_utf8_code_points_and_code_units(std::ranges::range auto input) {
+void print_utf8_code_points_and_code_units(std::ranges::range auto text) {
   auto print_code_point{
     [](char32_t code_point, auto code_unit_range) {
     std::println(
       "{:#x} = {::#x}", static_cast<std::uint32_t>(code_point),
       code_unit_range | std::views::transform([](char8_t c) { return (std::uint8_t)c; }));
     }};
-  auto code_points = input
+  auto code_points = text
                      | std::ranges::to<std::u8string>()
                      | std::views::to_utf32;
   for (auto it = code_points.begin(); it != code_points.end(); ++it) {
@@ -1364,7 +1528,7 @@ input view's code unit subsequences with additional refactoring:
 ```cpp
 constexpr bool is_utf8_continuation(char8_t c) { return (c & 0xC0) == 0x80; }
 
-void print_utf16_and_utf8_code_units_per_code_point(std::ranges::range auto input) {
+void print_utf16_and_utf8_code_units_per_code_point(std::ranges::range auto text) {
   auto print_code_point{
     [](auto u16_view, auto u8_view) {
       std::println(
@@ -1372,13 +1536,13 @@ void print_utf16_and_utf8_code_units_per_code_point(std::ranges::range auto inpu
         u16_view | std::views::transform([](char16_t c) { return (std::uint16_t)c; }),
         u8_view | std::views::transform([](char8_t c) { return (std::uint8_t)c; }));
     }};
-  auto it = input.begin();
+  auto it = text.begin();
   std::u8string code_point;
-  while (it != input.end()) {
+  while (it != text.end()) {
     code_point.clear();
     code_point.push_back(*it);
     ++it;
-    it = std::ranges::find_if(std::move(it), input.end(), [&](char8_t c) {
+    it = std::ranges::find_if(std::move(it), text.end(), [&](char8_t c) {
       if (!is_utf8_continuation(c)) return true;
       code_point.push_back(c);
       return false;
@@ -1398,19 +1562,16 @@ When invoked with `u8"AΩ€😀b"sv | std::views::as_input`, this prints:
 [0x62] = [0x62]
 ```
 
-Clearly, this isn't an ideal user experience, but it only applies to users who:
-
-- Need to access the underlying code unit sequence for a code point, and
-- Have a non-forward input range
-- That is too large to copy
-
-In my opinion, preserving the ergonomics of that use case is not worth the tradeoff of
-introducing the safety footgun demonstrated by the RLE example above.
+Clearly, this isn't an ideal user experience, but it only applies to users who have an
+input range that is too large to copy, and also need to access the underlying code unit
+sequence for a code point. In my opinion, preserving the ergonomics of that use case is
+not worth the tradeoff of introducing the safety footgun demonstrated by the RLE example
+above.
 
 ### Implementation
 
 An experimental implementation of `.base_code_units()` is available on the
-`enolan_basecodeunits1` branch of `beman.utf_view`.
+`enolan_basecodeunits2` branch of `beman.utf_view`.
 
 # Changelog
 


### PR DESCRIPTION
Also provide a survey of downgrading-to-input-range range adaptors.

<!--
Please take note of the following when contributing:
- Our code of conduct: https://github.com/bemanproject/beman/blob/main/docs/code_of_conduct.md
- The Beman Standard: https://github.com/bemanproject/beman/blob/main/docs/beman_standard.md
-->
