### PR TITLE
Enable beman-tidy default mode on beman.utf_view

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -45,6 +45,6 @@ repos:
     rev: v0.5.1
     hooks:
     - id: beman-tidy
-      args: [".", "--verbose", "--require-all"]
+      args: [".", "--verbose"]
 
 exclude: 'cookiecutter/|infra/|port/'

--- a/papers/generator/generator.sh
+++ b/papers/generator/generator.sh
@@ -1,5 +1,4 @@
 #!/usr/bin/env bash
-
 # SPDX-License-Identifier: BSL-1.0
 
 set -euo pipefail

--- a/papers/generator/post_clang_format.py
+++ b/papers/generator/post_clang_format.py
@@ -1,5 +1,4 @@
 #!/usr/bin/env python3
-
 # SPDX-License-Identifier: BSL-1.0
 
 import re


### PR DESCRIPTION
Issue: bemanproject/beman-tidy#265

## Problem
`beman-tidy` in default mode (requirements only) was failing on `file.license_id` for two paper generator scripts where the SPDX identifier was on line 3 instead of line 2.

Upstream `main` also had `--require-all` enabled in pre-commit prematurely.

## Changes
- Move SPDX headers to line 2 in `papers/generator/generator.sh` and `papers/generator/post_clang_format.py`
- Run `beman-tidy` in default mode on CI (remove `--require-all` from `.pre-commit-config.yaml`)

## beman-tidy results (local, default mode)
```
Summary    Requirement:  16 checks passed, 0 checks failed, 3 checks skipped
```

Recommendations still failing are already disabled in `.beman-tidy.yaml` (`license.apache_llvm`, `file.copyright`, `readme.implements`).

Supersedes #239 (could not reopen after force-push while closed).